### PR TITLE
Add libskbb_inmem.a native in-memory static target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,6 +105,11 @@ endif
 # plus the libskbb_wasm.a archive rule and WASM-only objects/tests.
 include wasm/emscripten_build.mk
 
+# Native in-memory static-archive build. Eigen backend, OpenMP enabled,
+# no LAPACKE/cblas/GPU. Provides INMEM_CXX / INMEM_CXXFLAGS used by the
+# skbb_cpu_tu macro below, plus the libskbb_inmem.a archive rule.
+include inmem_build.mk
+
 wasm: libskbb_wasm.a
 
 clean:
@@ -136,6 +141,8 @@ $(1).o: $(2) $(3)
 	$$(CXX) $$(CXXFLAGS) $(4) -c $$< -o $$@
 $(1).wasm.o: $(2) $(3)
 	$$(WASM_CXX) $$(WASM_CXXFLAGS) $(4) -c $$< -o $$@
+$(1).inmem.o: $(2) $(3)
+	$$(INMEM_CXX) $$(INMEM_CXXFLAGS) $(4) -c $$< -o $$@
 endef
 
 ##

--- a/src/inmem_build.mk
+++ b/src/inmem_build.mk
@@ -64,7 +64,11 @@ libskbb_inmem.a: $(INMEM_OBJS)
 inmem_static: libskbb_inmem.a
 
 # Install (archive + public headers under a stable prefix layout).
+# Guards against the empty-PREFIX footgun: the top-level Makefile falls
+# back to CONDA_PREFIX, but if both are unset `mkdir -p /lib` would
+# silently target the root filesystem.
 install_inmem: libskbb_inmem.a
+	@test -n "$(PREFIX)" || { echo "ERROR: PREFIX is unset (and CONDA_PREFIX is unset). Pass PREFIX=/path or activate a conda env."; exit 1; }
 	mkdir -p "${PREFIX}/lib" "${PREFIX}/include/scikit-bio-binaries"
 	rm -f "${PREFIX}/lib/libskbb_inmem.a"; cp libskbb_inmem.a "${PREFIX}/lib/"
 	for f in $(SHBB_EXTERN_HS); do rm -f "${PREFIX}/include/scikit-bio-binaries/$${f}"; cp "extern/$${f}" "${PREFIX}/include/scikit-bio-binaries/"; done

--- a/src/inmem_build.mk
+++ b/src/inmem_build.mk
@@ -1,0 +1,75 @@
+# Native in-memory static-archive build for scikit-bio-binaries.
+#
+# Activated by the top-level `inmem_static` target. Produces
+# libskbb_inmem.a — the same in-memory subset shipped as libskbb_wasm.a
+# (Eigen backend, no LAPACKE/cblas, no GPU, no CPU-arch dispatch),
+# but compiled with the host toolchain so OpenMP is enabled. Intended
+# for downstream native projects that want to embed the in-memory
+# scikit-bio-binaries surface without dragging in BLAS/LAPACK.
+#
+# Per-translation-unit rules for sources shared with the native and
+# WASM builds are defined in src/Makefile via the `skbb_cpu_tu` canned
+# recipe (one definition emits .o, .wasm.o, AND .inmem.o rules). This
+# file owns:
+#   - the inmem compiler vars (used by skbb_cpu_tu)
+#   - the inmem-only TU (Eigen linalg backend, native CXX)
+#   - the libskbb_inmem.a archive rule
+#   - install / clean targets
+#
+# Invocation: this Makefile fragment is included from src/Makefile and
+# must be run with src/ as the working directory.
+
+# Reuse the Eigen drop fetched by scripts/fetch_eigen.sh for the WASM
+# build — the headers don't care which compiler is consuming them.
+INMEM_REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+INMEM_EIGEN_INC := $(INMEM_REPO_ROOT)/.wasm-cache/eigen/include
+
+INMEM_CXX      ?= $(CXX)
+INMEM_AR       ?= ar
+INMEM_MPFLAG   ?= -fopenmp
+INMEM_CXXFLAGS := -std=c++17 -O3 -Wall -fPIC -I. \
+                  -I$(INMEM_EIGEN_INC) \
+                  -DSKBB_BLAS_BACKEND_EIGEN=1 \
+                  -DEIGEN_DONT_PARALLELIZE \
+                  -DNOGPU=1 \
+                  $(INMEM_MPFLAG) \
+                  -Wno-unknown-pragmas
+
+# Object list for the inmem archive. Stems must match the .inmem.o
+# targets emitted by skbb_cpu_tu in src/Makefile, plus the Eigen-backed
+# linalg implementation defined below. Mirrors WASM_OBJS — same TU set.
+INMEM_OBJS := \
+    util_rand.inmem.o \
+    skbb_detect_acc.inmem.o \
+    skbb_accapi_cpu.inmem.o \
+    dist_permanova.inmem.o \
+    permanova_cpu.inmem.o \
+    ord_pcoa.inmem.o \
+    ord_linalg_backend_eigen.inmem.o \
+    skbb_extern_util.inmem.o \
+    skbb_extern_distance.inmem.o \
+    skbb_extern_ordination.inmem.o
+
+# Inmem-only TU: the Eigen-backed linalg backend has no symmetric-macro
+# equivalent because the native build uses linalg_backend_lapacke.cpp
+# under the same `ord_linalg_backend.o` stem. Same source as the WASM
+# rule, just compiled with $(INMEM_CXX) instead of em++.
+ord_linalg_backend_eigen.inmem.o: ordination/linalg_backend_eigen.cpp ordination/linalg_backend.hpp
+	$(INMEM_CXX) $(INMEM_CXXFLAGS) -c $< -o $@
+
+libskbb_inmem.a: $(INMEM_OBJS)
+	rm -f $@
+	$(INMEM_AR) rcs $@ $(INMEM_OBJS)
+
+inmem_static: libskbb_inmem.a
+
+# Install (archive + public headers under a stable prefix layout).
+install_inmem: libskbb_inmem.a
+	mkdir -p "${PREFIX}/lib" "${PREFIX}/include/scikit-bio-binaries"
+	rm -f "${PREFIX}/lib/libskbb_inmem.a"; cp libskbb_inmem.a "${PREFIX}/lib/"
+	for f in $(SHBB_EXTERN_HS); do rm -f "${PREFIX}/include/scikit-bio-binaries/$${f}"; cp "extern/$${f}" "${PREFIX}/include/scikit-bio-binaries/"; done
+
+inmem_clean:
+	rm -f libskbb_inmem.a *.inmem.o
+
+.PHONY: inmem_static install_inmem inmem_clean


### PR DESCRIPTION
## Summary

Adds a native counterpart to ``libskbb_wasm.a``: a static archive built with the host toolchain, OpenMP enabled, Eigen-backed, with no LAPACKE/cblas surface.

Motivation: a downstream project ([duckdb-miint](https://github.com/biocore/unifrac-binaries)) wants to embed scikit-bio-binaries' in-memory analytical surface (PCoA, PERMANOVA) inside a DuckDB extension as a single statically-linked library. The existing ``libskbb.so`` works but drags LAPACKE/cblas at runtime; ``libskbb_wasm.a`` is the right shape but emcc-only. ``libskbb_inmem.a`` closes that gap for native CXX consumers.

A companion PR in [unifrac-binaries](https://github.com/biocore/unifrac-binaries) adds a corresponding ``libssu_inmem.a`` whose end-to-end full-static link is what motivates this change. Together the two archives produce a binary with no project-related runtime dependencies (only stdc++/m/gomp/gcc_s/c).

Two commits:
- ``5d76c40`` Add libskbb_inmem.a native in-memory static target
- ``e2ca259`` Guard install_inmem against unset PREFIX

## Implementation

- New ``src/inmem_build.mk`` defining ``INMEM_CXX``/``INMEM_CXXFLAGS``, the inmem-only Eigen linalg backend rule, and ``libskbb_inmem.a`` / ``install_inmem`` / ``inmem_clean`` targets. Reuses the Eigen drop fetched by ``scripts/fetch_eigen.sh`` for the WASM build.
- Extends the existing ``skbb_cpu_tu`` macro in ``src/Makefile`` to emit a third ``.inmem.o`` rule alongside ``.o`` and ``.wasm.o`` — any future symmetric TU added to either build automatically picks up the inmem variant.
- ``-DEIGEN_DONT_PARALLELIZE`` is set in ``INMEM_CXXFLAGS``: with ``_OPENMP`` defined Eigen parallelizes its internal matrix ops, which makes seeded PCoA non-deterministic across re-runs. The WASM build dodges this by omitting ``-fopenmp``; the LAPACKE-backed native libskbb dodges it by bypassing Eigen entirely. The inmem build is the only combo where both Eigen and OpenMP are present.
- ``install_inmem`` guards against the empty-PREFIX footgun (errors out instead of installing into ``/lib``).

## Test plan

- [x] ``make inmem_static`` builds cleanly from a fresh checkout (1.5M archive)
- [x] ``nm libskbb_inmem.a`` shows zero LAPACK/BLAS/HDF5/lz4 undefined symbols; only standard libc++/openmp externals remain
- [x] ``make wasm`` rebuild from scratch produces a byte-equivalent ``libskbb_wasm.a`` (the macro extension is purely additive, no WASM regression)
- [x] End-to-end: linking the unifrac-binaries C-API test against ``libssu_inmem.a + libskbb_inmem.a`` yields a binary whose ``ldd`` shows no project runtime dependencies, and all inmem unit tests pass (UniFrac compute, faith_pd, subsample, PERMANOVA, PCoA)
- [x] ``make install_inmem`` with PREFIX/CONDA_PREFIX both unset fails with a clear error message (rather than silently writing to ``/lib``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)