### PR TITLE
Add CLAUDE.md and docs/ guidance for LLM-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## ABSOLUTE HARD REQUIREMENTS
+- NEVER use `rm` without permission
+- NEVER commit generated files (`src/*.cpp` at that level, `src/tests/wasm/expected/`, `*.o`, `*.a`)
+- NEVER `git add -A`, `git add .`, or `git commit -a` — stage explicit paths
+
+## Project Overview
+
+**scikit-bio-binaries** provides optimized C/C++ implementations of numerical
+algorithms in support of `scikit-bio`, exposed as a flat C ABI (`skbb_*`) from
+`libskbb.so`. Two algorithms today: **PERMANOVA** and **PCoA via FSVD**.
+
+The distinguishing property is that hot kernels are compiled multiple times —
+per x86 microarchitecture level and per GPU vendor — and selected **at runtime**,
+with GPU support arriving through `dlopen`'d plugin libraries so a GPU-enabled
+build still runs on a GPU-less machine. Three build flavors (native shared
+library, WebAssembly static archive, native Eigen-only static archive) share one
+set of sources and expose an identical symbol set.
+
+This repo is upstream `scikit-bio/scikit-bio-binaries`, maintained by
+@sfiligoi. We contribute via PRs from the `the-miint` fork.
+
+## Priorities
+
+1. Red/green/refactor Test Driven Development (TDD)
+2. Verifiably correct code
+3. Maintainable code, using Don't Repeat Yourself (DRY) and Keep It Simple Stupid (KISS)
+4. Performance
+
+## Rules
+
+These rules apply to every task in this project unless explicitly overridden.
+
+### Rule 1 — Think Before Coding
+Bias: caution over speed on non-trivial work.
+State assumptions explicitly. Ask rather than guess.
+Push back when a simpler approach exists. Stop when confused.
+
+### Rule 2 — Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+No abstractions for single-use code.
+
+### Rule 3 — Surgical Changes
+Touch only what you must. Don't improve adjacent code.
+Match existing style. Don't refactor what isn't broken.
+
+### Rule 4 — Goal-Driven Execution
+Define success criteria. Loop until verified.
+
+### Rule 5 — Surface conflicts, don't average them
+If two patterns contradict, pick one (more recent / more tested).
+Explain why. Flag the other for cleanup.
+
+### Rule 6 — Read before you write
+Before adding code, read exports, immediate callers, shared utilities.
+If unsure why existing code is structured a certain way, ask.
+
+### Rule 7 — Tests verify intent, not just behavior
+Tests must encode WHY behavior matters, not just WHAT it does.
+A test that can't fail when business logic changes is wrong.
+
+### Rule 8 — Checkpoint after every significant step
+Summarize what was done, what's verified, what's left.
+Don't continue from a state you can't describe back.
+
+### Rule 9 — Match the codebase's conventions, even if you disagree
+Conformance > taste inside the codebase.
+If you think a convention is harmful, surface it. Don't fork silently.
+
+### Rule 10 — Fail loud
+"Completed" is wrong if anything was skipped silently.
+Don't silently skip tests you caused to be skipped.
+Default to surfacing uncertainty, not hiding it.
+
+## Style, churn, and comments — non-negotiable here
+
+There is **no formatter and no format check in this repo**. Nothing will undo a
+gratuitous reformat, and every extra line is reviewer cost paid by the upstream
+maintainer. Full detail in **[`docs/code-style.md`](docs/code-style.md)** — read
+it before your first edit in a session that writes code. The three rules that
+matter most:
+
+1. **Match the file you are editing.** Indentation is genuinely inconsistent
+   across this tree (1-space, 2-space, 4-space, tabs) and there is no globally
+   correct answer. Copy the local convention.
+2. **No unnecessary churn.** No reformatting, re-wrapping, re-ordering,
+   typo-fixing, or modernizing outside the functional change you were asked for.
+   Unrelated fixes — including anything in
+   [`docs/known-issues.md`](docs/known-issues.md) — get their own commit and
+   their own test.
+3. **Comments must be succinct and durable.** Explain *why*, in the shortest form
+   that survives. Write for someone reading the file in two years who knows
+   nothing about the current change. **Never narrate the work**: no "Stage 3",
+   no "per reviewer guidance", no "previous fix tried…", no PR numbers. That
+   belongs in the commit message. The tree already contains such comments and
+   they have gone stale and now mislead.
+
+Standing maintainer feedback (from PR review history): **do not duplicate build
+infrastructure** — add a translation unit in one place, via the `skbb_cpu_tu`
+macro; **do not commit generated artifacts**; and prefer the boring solution,
+because complexity in the build/dispatch layer gets flagged.
+
+## Build Commands
+
+Conda-provided compilers recommended; system ones work.
+
+```bash
+conda create -n skbb-build -c conda-forge gxx_linux-64      # or clangxx_osx-* on macOS
+conda activate skbb-build
+conda install -c conda-forge libcblas liblapacke blas-devel make
+
+make clean && make clean_install && make all   # api + install + test binaries
+make test                                      # native unit tests + public C API tests
+```
+
+WebAssembly (needs an activated emsdk ≥ 5.0.3 and node ≥ 18):
+
+```bash
+scripts/fetch_eigen.sh    # pinned Eigen 3.4.0 into .wasm-cache/
+make wasm                 # src/libskbb_wasm.a
+make wasm_test            # smoke, PERMANOVA, centering, PCoA under node
+make wasm_api_test        # public C API parity
+```
+
+Native Eigen-only static archive (no top-level target):
+
+```bash
+make -C src inmem_static  # src/libskbb_inmem.a
+```
+
+GPU builds are off by default: `export NV_CUDA=Y` (needs `cuda-compiler`) or
+`export AMD_HIP=Y` (needs `hipcc`).
+
+Useful at runtime: `SKBB_USE_GPU=N`, `SKBB_MAX_CPU=basic`, `SKBB_GPU_INFO=Y`,
+`SKBB_CPU_INFO=Y`, `SKBB_TIMING_INFO=Y`, `OMP_NUM_THREADS`.
+
+## Testing
+
+If a test produces an **incorrect expected value**: DO NOT change the expected
+value without permission.
+
+Run `make test` with a non-power-of-two `OMP_NUM_THREADS` (CI uses 3) — chunking
+bugs hide at 1 thread. `OMP_NUM_THREADS` changes seeded PERMANOVA p-values by
+design; see [`docs/determinism-and-numerics.md`](docs/determinism-and-numerics.md).
+
+## Architecture and Patterns (detailed docs)
+
+Load only what the task needs.
+
+- **[`docs/architecture.md`](docs/architecture.md)** — the layer cake (public C ABI → `skbb::` core → per-variant dispatch namespaces → kernels), directory map, naming conventions, the three build flavors, and the **`SKBB_ACC_NM` multi-include idiom** (headers deliberately without include guards — adding one breaks the build in a confusing way). Start here.
+- **[`docs/code-style.md`](docs/code-style.md)** — per-file conventions, comment policy, what the maintainer has pushed back on. Read before writing code.
+- **[`docs/build-system.md`](docs/build-system.md)** — Make targets and variables, the `skbb_cpu_tu` canned recipe, generated sources, install/clean footguns, CI layout. Read when touching any Makefile or adding a translation unit.
+- **[`docs/codegen.md`](docs/codegen.md)** — the Python generators that expand `_T`-suffixed kernels into `direct`/`indirect`/`api`/`api_h` wrappers. Read before editing `permanova_dyn_impl.hpp` or `skbb_accapi_impl.hpp`; the parser is positional and fails silently.
+- **[`docs/acceleration-dispatch.md`](docs/acceleration-dispatch.md)** — runtime CPU/GPU selection, all environment variables, the `dlopen` plugin mechanism, and the device-buffer API (CUDA/HIP return a *distinct* pointer; OpenACC/OpenMP-target do not).
+- **[`docs/permanova.md`](docs/permanova.md)** — the statistic, the chunked permutation loop, `NBLOCK`/`TILE` blocking, the CUDA and OpenACC kernels, and the caller contract (dense 0-based groupings) that nothing validates.
+- **[`docs/pcoa-fsvd.md`](docs/pcoa-fsvd.md)** — centering math, the six FSVD steps, the three-function linalg backend and its **column-major `svd_no` stride contract**, output layouts, and the aliasing rules between output buffers.
+- **[`docs/determinism-and-numerics.md`](docs/determinism-and-numerics.md)** — what is bit-reproducible and what is not, why `std::shuffle` is banned, and the list of changes that silently alter seeded p-values. Read before touching RNG, chunk sizes, or accumulation order.
+- **[`docs/testing.md`](docs/testing.md)** — the four suites, the native→WASM expected-value generation flow, tolerances, and how to add tests.
+- **[`docs/public-c-api.md`](docs/public-c-api.md)** — every exported symbol, buffer sizes and ownership, and the API-versioning rules to follow when adding a function.
+- **[`docs/known-issues.md`](docs/known-issues.md)** — verified defects (including a real PERMANOVA correctness bug in the partial-chunk path), suspected ones, and latent build fragilities. Check here before debugging something odd; do not fix these as drive-bys.

--- a/docs/acceleration-dispatch.md
+++ b/docs/acceleration-dispatch.md
@@ -1,0 +1,136 @@
+# Acceleration & runtime dispatch
+
+Two orthogonal selections happen at runtime, both implemented in
+`src/util/skbb_detect_acc.cpp`:
+
+1. **Accelerator**: CPU / NVIDIA / AMD (`check_use_acc()`, line 65).
+2. **x86 microarchitecture level**: base / v3 (AVX2) / v4 (AVX512)
+   (`check_use_cpu_x86()`, line 214). Compiled in only when
+   `SKBB_ENABLE_CPU_X86_LEVELS` is defined — x86_64 Linux only.
+
+Both cache their answer in a file-static `int` initialized to `-1`, so detection
+runs once per process. The comment `// we can assume int is atomic` is the
+extent of the thread-safety argument: a benign race where two threads both run
+detection and store the same value.
+
+## Accelerator selection
+
+```
+detected = ACC_CPU
+if SKBB_ENABLE_ACC_NV  and skbb_acc_nv::acc_found_gpu():   detected = ACC_NV
+    unless SKBB_USE_NVIDIA_GPU ∈ {N,NO,n,no,NEVER,never}
+if SKBB_ENABLE_ACC_AMD and skbb_acc_amd::acc_found_gpu():  detected = ACC_AMD   (only if still CPU)
+    unless SKBB_USE_AMD_GPU ∈ {…}
+if SKBB_USE_GPU ∈ {N,NO,n,no,NEVER,never}:                 detected = ACC_CPU
+```
+
+NVIDIA wins over AMD when both are present. `acc_found_gpu()` for a variant is a
+`dlopen` of that variant's plugin — see below.
+
+Public overrides (`src/extern/util.h`):
+
+* `skbb_get_acc_mode()` → `SKBB_ACC_CPU|NV|AMD` (0/1/2), forcing detection.
+* `skbb_set_acc_mode(t)` → returns `false` and changes nothing if `t` names a
+  variant this build wasn't compiled with. Sets the cached value, so it also
+  works as a "skip detection" switch.
+* `skbb_is_acc_reporting()` / `skbb_set_acc_reporting_flag(bool)`.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `SKBB_USE_GPU=N` | force CPU (any accelerator) |
+| `SKBB_USE_NVIDIA_GPU=N` / `SKBB_USE_AMD_GPU=N` | disable one vendor |
+| `SKBB_GPU_INFO=Y` | print accelerator selection decisions to stdout; also makes `skbb_dl.cpp` announce which plugin `.so` it loaded |
+| `SKBB_MAX_CPU=basic\|base\|x86-64-v2\|sse\|sse3\|sse4\|avx` | cap at base; `x86-64-v3`/`avx2` caps at v3. Unknown strings are ignored silently. |
+| `SKBB_CPU_INFO=Y` | print x86 level selection |
+| `SKBB_TIMING_INFO=Y` | per-phase wall-clock via the `SETUP_TDBG`/`TDBG_STEP` macros in `util/skbb_dgb_info.hpp` |
+| `OMP_NUM_THREADS` | standard OpenMP. **Changes seeded PERMANOVA p-values** — see [`determinism-and-numerics.md`](determinism-and-numerics.md). |
+
+The truthiness convention is inverted and worth noting: for the `*_INFO`
+variables, *any* value enables reporting **except** the explicit negatives
+(`NO`, `N`, `no`, `n`, `NEVER`, `never`). `SKBB_GPU_INFO=0` therefore turns
+reporting **on**.
+
+One inconsistency: `skbb_dl.cpp:31` and `:74` check `env_cpu_info[0]=='Y'`
+rather than using the same negative-list convention, so `SKBB_GPU_INFO=y` prints
+the selection messages but not the "Using shared library …" line.
+
+## The dlopen plugin mechanism
+
+`libskbb.so` never links CUDA/HIP. Instead, `generate_*.py … indirect` emits
+stubs that lazily resolve symbols out of a sibling `.so`:
+
+```
+libskbb.so
+  skbb_acc_nv::acc_found_gpu()      -> dl_load_check()      -> dlopen("libskbb_acc_nv.so")
+  skbb_acc_nv::pmn_f_stat_sW<double>-> cond_dl_load("skbb_acc_nv_pmn_f_stat_sW_double")
+                                                            -> dlsym
+```
+
+`src/util/skbb_dl.cpp` (textually `#include`d into each generated stub file, so
+each has its own `dl_handle` and mutex):
+
+* `dl_load_check()` — `dlopen` with `RTLD_LAZY`; returns `false` if the library
+  is absent. **Only `acc_found_gpu` uses this soft path.**
+* `cond_dl_load(name, &ptr)` — mutex-guarded lazy `dlsym`; on any failure it
+  prints to stderr and `exit(1)`. Hard failure by design: if detection said the
+  GPU is there, a missing symbol is a build inconsistency.
+* The `.so` is found through the normal loader search path (`LD_LIBRARY_PATH`,
+  rpath); there is no absolute path or version suffix — `dl_get_lib_name()`
+  returns the bare `"libskbb_acc_nv.so"`.
+
+Consequence: a plugin built against a different `skbb` version will be loaded
+happily as long as the symbol names match. The `skbb_get_api_version()`
+mechanism does **not** cover the plugin boundary.
+
+## The accelerator buffer API (`skbb_accapi`)
+
+`src/util/skbb_accapi_impl.hpp` is a 6-primitive abstraction over "move a buffer
+to the device", specialized by `#if` on `SKBB_CUDA` / `SKBB_HIP` / `OMPGPU` /
+`_OPENACC` / nothing:
+
+| Primitive | CUDA / HIP | OpenACC / OpenMP-target | plain CPU |
+|---|---|---|---|
+| `acc_create_buf(host, &dev, n)` | `cudaMalloc` → **new pointer** | `enter data create`, `dev = host` | `dev = host` |
+| `acc_copyin_buf(host, &dev, n)` | `cudaMalloc` + `Memcpy H2D` | `enter data copyin`, `dev = host` | `dev = host` |
+| `acc_update_device(host, dev, start, end)` | `Memcpy` of the slice | `update device(host[start:end])` | no-op |
+| `acc_copyout_buf(host, dev, n)` | `Memcpy D2H` + free | `exit data copyout` | no-op |
+| `acc_destroy_buf(dev, n)` | `cudaFree` | `exit data delete` | no-op |
+| `acc_found_gpu()`, `acc_need_alt()`, `acc_wait()` | device count / sync | ditto | `false` / `false` / no-op |
+
+**The critical asymmetry**: under CUDA/HIP the device pointer is a *distinct*
+allocation and host memory is untouched until `copyout`; under
+OpenACC/OpenMP-target the device pointer *is* the host pointer with a mapping
+attached. Orchestration code must therefore keep both `x` and `x_device`
+variables and never assume they differ (see
+`src/distance/permanova.cpp:123-148`).
+
+CUDA/HIP failures `throw std::runtime_error`. Nothing in `libskbb.so` catches
+them, and the public C ABI has no error channel — a CUDA OOM propagates out of
+an `extern "C"` function, which is UB for C callers. Treat GPU paths as
+abort-on-failure.
+
+## x86 level dispatch
+
+Only PERMANOVA's inner kernel is dispatched this way — three copies of
+`pmn_f_stat_sW` are compiled (`-march=x86-64-v3`, `-march=x86-64-v4`, and
+baseline) into `skbb_cpu_x86_v3::`, `skbb_cpu_x86_v4::`, `skbb_cpu::`. Selection
+uses `__builtin_cpu_init()` + `__builtin_cpu_supports("x86-64-v4"/"v3")`.
+
+`pmn_get_max_parallelism()` is deliberately taken from `skbb_cpu::` regardless of
+the selected level (`src/distance/permanova.cpp:97`) — the chunk size must not
+depend on the microarchitecture, or seeded results would differ between machines.
+
+PCoA is *not* x86-dispatched; it relies on `#ifdef __AVX2__`/`__AVX__` inside
+`E_matrix_means` (`principal_coordinate_analysis.cpp:58-114`), evaluated against
+the flags of the single baseline compile — i.e. **the unrolled paths are dead
+code in the default build** and BLAS does the heavy lifting anyway.
+
+## What wasm/inmem see
+
+Neither defines `SKBB_ENABLE_ACC_NV/AMD` nor `SKBB_ENABLE_CPU_X86_LEVELS`, so all
+the `#if`-guarded blocks vanish: `check_use_acc()` always returns `ACC_CPU`,
+`skbb_set_acc_mode(SKBB_ACC_NV)` returns `false`, and the only surviving
+`skbb_accapi` implementation is the identity (`dev = host`). The `skbb_accapi_cpu`
+objects are still built and linked — they're the no-op path.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,155 @@
+# Architecture
+
+`scikit-bio-binaries` is a small, self-contained numerical library. It exports a
+flat **C ABI** (`skbb_*`) from a shared library `libskbb.so`, implemented in
+C++17, with optional per-CPU-generation and per-GPU-vendor variants of the hot
+kernels selected **at runtime**.
+
+There are exactly two algorithms today: **PERMANOVA** (`src/distance/`) and
+**PCoA via FSVD** (`src/ordination/`). Everything else in the tree exists to
+build, dispatch, seed, or test those two.
+
+---
+
+## The layer cake
+
+```
+    caller (C, ctypes, emscripten, …)
+        │
+   ┌────▼──────────────────────────────────────────────┐
+   │ 1. Public C ABI          src/extern/*.h + *.cpp   │  extern "C" skbb_*
+   │    thin, no logic, just unwraps pointers          │
+   └────┬──────────────────────────────────────────────┘
+        │
+   ┌────▼──────────────────────────────────────────────┐
+   │ 2. Algorithm core        skbb::                   │  templated on TFloat,
+   │    src/distance/permanova.cpp                     │  instantiated for
+   │    src/ordination/principal_coordinate_analysis.cpp│ float + double
+   │    owns memory, blocking, RNG, orchestration      │
+   └────┬───────────────────────────┬──────────────────┘
+        │                           │
+   ┌────▼─────────────────────┐ ┌───▼───────────────────┐
+   │ 3a. Kernel dispatch      │ │ 3b. Linalg backend    │
+   │  skbb_cpu::              │ │  skbb::linalg::       │
+   │  skbb_cpu_x86_v3::       │ │  compile-time choice: │
+   │  skbb_cpu_x86_v4::       │ │  LAPACKE  |  Eigen    │
+   │  skbb_acc_nv::           │ └───────────────────────┘
+   │  skbb_acc_amd::          │
+   │  chosen at RUNTIME       │
+   └────┬─────────────────────┘
+        │
+   ┌────▼──────────────────────────────────────────────┐
+   │ 4. Kernels    distance/permanova_dyn_impl.hpp     │  one source, compiled
+   │               util/skbb_accapi_impl.hpp           │  N times with different
+   │               #if on SKBB_CPU/CUDA/HIP/OMPGPU/ACC │  flags & compilers
+   └───────────────────────────────────────────────────┘
+```
+
+Layer 3a is the unusual part and is described in
+[The `SKBB_ACC_NM` idiom](#the-skbb_acc_nm-idiom) below and in
+[`acceleration-dispatch.md`](acceleration-dispatch.md).
+
+---
+
+## Directory map
+
+| Path | Contents |
+|---|---|
+| `src/extern/` | Public C headers (`util.h`, `distance.h`, `ordination.h`) + their thin `extern "C"` implementations. **This is the shipped API surface.** Installed to `$PREFIX/include/scikit-bio-binaries/`. |
+| `src/distance/` | PERMANOVA. `permanova.{hpp,cpp}` = orchestration; `permanova_dyn.hpp` = the per-variant namespace declaration; `permanova_dyn_impl.hpp` = the actual kernels. |
+| `src/ordination/` | PCoA/FSVD. `principal_coordinate_analysis.{hpp,cpp}` + a 3-function linear-algebra backend (`linalg_backend.hpp` with `_lapacke.cpp` / `_eigen.cpp` implementations). |
+| `src/util/` | `rand.*` (global + per-thread RNG), `portable_shuffle.hpp`, `skbb_detect_acc.*` (runtime selection), `skbb_accapi*.hpp` (GPU buffer primitives), `skbb_dl.cpp` (dlopen shim), `skbb_dgb_info.hpp` (timing macros). |
+| `src/tools/` | The Python code generators. See [`codegen.md`](codegen.md). |
+| `src/wasm/`, `src/inmem_build.mk` | Alternate build flavors (Makefile fragments). |
+| `src/tests/` | Native C++ tests (hand-rolled harness) + `tests/wasm/` for the WASM parity suite. |
+| `api_tests/` | Black-box tests of the installed shared library through the public C headers, compiled as **C99**. |
+| `scripts/` | `fetch_eigen.sh` (pinned Eigen drop for WASM/inmem), compiler-enable helpers. |
+
+There are **no sources checked in at the top of `src/`** — everything lives in a
+subdirectory. `make -C src clean` runs `rm -f *.cpp *.hpp *.h *.cu` in `src/`
+precisely because every file matching those globs there is generated. Never put
+a hand-written source directly in `src/`.
+
+---
+
+## The `SKBB_ACC_NM` idiom
+
+The same kernel source is compiled several times, once per hardware variant,
+each time into a *different C++ namespace*. The namespace name is injected by a
+macro on the compiler command line:
+
+```make
+$(CXX) $(CXXFLAGS) -DSKBB_ACC_NM=skbb_cpu_x86_v3 $(X86V3FLAGS) -c permanova_cpu_x86_v3.cpp
+```
+
+`distance/permanova_dyn.hpp` and `util/skbb_accapi.hpp` are written to be
+included **multiple times in one translation unit**, each time with a different
+`SKBB_ACC_NM`:
+
+```cpp
+// src/distance/permanova.cpp:19-47
+#define SKBB_ACC_NM  skbb_cpu
+#include "distance/permanova_dyn.hpp"
+#undef SKBB_ACC_NM
+
+#ifdef SKBB_ENABLE_CPU_X86V3
+#define SKBB_ACC_NM  skbb_cpu_x86_v3
+#include "distance/permanova_dyn.hpp"
+#undef SKBB_ACC_NM
+#endif
+…
+```
+
+Two consequences you must not break:
+
+1. **These headers deliberately have no `#ifndef`/`#define` include guard.**
+   `permanova_dyn.hpp` and `skbb_accapi.hpp` guard on `#ifdef SKBB_ACC_NM`
+   instead (expanding to nothing when the macro is absent). Adding a
+   conventional include guard silently reduces them to a single namespace and
+   the build fails at link time with missing `skbb_cpu_x86_v3::…` symbols.
+2. The declarations are **templates without definitions**; the definitions are
+   explicit specializations emitted by the generators into
+   `permanova_cpu*.cpp` / `skbb_accapi_*.cpp`. Adding a new type to a kernel
+   means teaching the generator about it, not just adding a call site.
+
+## Naming conventions
+
+| Pattern | Meaning |
+|---|---|
+| `skbb_foo_fp64` / `_fp32` (extern "C") | Public ABI. `fp64_to_fp32` = double input, float output. |
+| `skbb::foo` | Internal C++ API, overloaded on `float`/`double`. |
+| `foo_T(...)` / `template<class TFloat> foo_T` | An *implementation* function. **The `_T` suffix is load-bearing**: the generators scan for `static inline … _T(` and emit wrappers for exactly those. See [`codegen.md`](codegen.md). |
+| `skbb_cpu::`, `skbb_cpu_x86_v3::`, `skbb_cpu_x86_v4::`, `skbb_acc_nv::`, `skbb_acc_amd::` | Per-variant dispatch namespaces (layer 3a). |
+| `skbb_acc_nv_pmn_f_stat_sW_double` | The flat `extern "C"` symbol inside a GPU plugin `.so`, resolved by `dlsym`. Shape: `<namespace>_<function>_<type>`. |
+| `TFloat` / `TNum` / `TReal` | Template type parameters. `TFloat` → generator emits `{float,double}`; `TNum` → `{float,double,uint64_t,uint32_t,bool}`. |
+
+## Build flavors
+
+Three archives/libraries are produced from largely the same sources. See
+[`build-system.md`](build-system.md) for the mechanics.
+
+| Flavor | Output | Linalg | Threads | GPU | x86 dispatch |
+|---|---|---|---|---|---|
+| native (default) | `libskbb.so` (+ optional `libskbb_acc_nv.so`, `libskbb_acc_amd.so`) | cblas + LAPACKE | OpenMP | dlopen'd plugins | yes, on x86_64 Linux |
+| wasm | `src/libskbb_wasm.a` | Eigen (header-only) | none | no | no |
+| inmem | `src/libskbb_inmem.a` | Eigen (header-only) | OpenMP | no | no |
+
+The public `skbb_*` symbol set is **identical** across all three. Callers cannot
+tell them apart except through `skbb_get_acc_mode()` (always `SKBB_ACC_CPU` for
+wasm/inmem) and performance.
+
+## Adding a new algorithm — checklist
+
+1. Core in `src/<area>/<algo>.{hpp,cpp}`, templated `_T` helper + `float`/`double`
+   instantiations in namespace `skbb`.
+2. Public header `src/extern/<area>.h`: add a `#define SKBB_<NAME>_API_MIN_VERSION`
+   constant and the `extern "C"` declarations; bump `SKBB_API_CURRENT_VERSION`
+   in `src/extern/util.h`. Add the header to `SHBB_EXTERN_HS` in `src/Makefile`
+   if it is new (it is installed and cleaned by name).
+3. Thin wrapper in `src/extern/skbb_<area>.cpp`.
+4. Register the translation unit **once** with the `skbb_cpu_tu` macro in
+   `src/Makefile` (this emits the native `.o`, `.wasm.o` and `.inmem.o` rules)
+   and add the object to `SKBB_OBJS`, `WASM_OBJS`, `INMEM_OBJS`.
+5. If it needs a runtime-dispatched kernel, follow [`codegen.md`](codegen.md).
+6. Tests: native (`src/tests/`), public-API (`api_tests/`), and WASM parity
+   (`src/tests/wasm/`) — see [`testing.md`](testing.md).

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -1,0 +1,170 @@
+# Build system
+
+Plain GNU Make, no CMake, no autotools. Two Makefiles plus two included
+fragments:
+
+```
+Makefile                     # thin dispatcher, `cd src && $(MAKE) <target>`
+src/Makefile                 # all native rules; includes the two fragments
+src/wasm/emscripten_build.mk # WASM flavor
+src/inmem_build.mk           # native-Eigen static-archive flavor
+api_tests/Makefile           # black-box tests against the installed .so
+api_tests/wasm/Makefile      # same tests under emcc
+```
+
+Both fragments are `include`d from `src/Makefile` and **assume `src/` is the
+working directory** — every path in them is relative to `src/`.
+
+## Targets
+
+### Top level
+
+| Target | Does |
+|---|---|
+| `all` | `api` + `install` + `test_bins` |
+| `api` | build `libskbb.so` (+ GPU plugins if enabled) |
+| `install` | copy shared libs to `$PREFIX/lib`, public headers to `$PREFIX/include/scikit-bio-binaries` |
+| `test_bins` | build `src/*.exe` and `api_tests/*.exe` |
+| `test` | build + run both test suites |
+| `clean`, `clean_install` | see gotchas below |
+| `wasm` | `scripts/fetch_eigen.sh` then `src/libskbb_wasm.a` |
+| `wasm_test` | build + run the four WASM unit tests under node |
+| `wasm_api_test` | build + run `api_tests/` under emcc/node |
+| `wasm_clean` | remove WASM artifacts |
+
+`.NOTPARALLEL:` is set at the top level on purpose: the native and WASM DAGs
+share generated sources (`permanova_cpu.cpp`, `skbb_accapi_cpu.cpp`), and
+`make -j all wasm` would otherwise run the same Python generator twice
+concurrently and truncate its own output file. Sub-makes keep their internal
+parallelism.
+
+### `src/` only (no top-level passthrough)
+
+| Target | Does |
+|---|---|
+| `inmem_static` | build `libskbb_inmem.a` |
+| `install_inmem` | install the archive + headers |
+| `inmem_clean` | remove `libskbb_inmem.a` and `*.inmem.o` |
+
+There is **no `inmem*` target in the root `Makefile`** — invoke it as
+`make -C src inmem_static`. (The inmem flavor is newer than the rest of the
+build; `src/inmem_build.mk` is a recent addition.)
+
+## Key variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `PREFIX` | `$CONDA_PREFIX` | Install root. **If both are unset, `src/Makefile`'s `install` does `mkdir -p /lib`** — no guard. `install_inmem` in `inmem_build.mk` *does* guard. |
+| `BLASLIB` | `-llapacke -lcblas` | Conditional (`?=`) so env/CLI can override. Ubuntu needs `-llapacke -lopenblas`; `libcblas.so` under that exact name comes from ATLAS. CI overrides it. |
+| `NOGPU` | set automatically on Darwin | Disables `SKBB_ENABLE_ACC_NV/AMD` and the `-ldl` link. |
+| `NV_CUDA=Y` | unset | Build the NVIDIA plugin with `nvcc` (`-DSKBB_CUDA`, `-arch=all-major`). |
+| `AMD_HIP=Y` | unset | Build the AMD plugin with `hipcc` (`-DSKBB_HIP`, fixed `--offload-arch` list). |
+| `NV_CXX` / `AMD_CXX` | unset | Experimental OpenACC (`nvc++`) / OpenMP-target (`amdclang++`) plugins instead. `scripts/enable_{nv,amd}_compiler.sh` set these. |
+| `OPT` | empty | Extra flags appended to every compile line. |
+
+Native `CXXFLAGS` are fixed at `-O3 -ffast-math -fopenmp -Wall -std=c++17
+-pedantic -I. -fPIC`. Note `-ffast-math`: reassociation is permitted, so
+bit-exactness across compilers/optimization levels is not guaranteed for the
+float paths — see [`determinism-and-numerics.md`](determinism-and-numerics.md).
+
+On x86_64 non-Darwin, `SKBB_ENABLE_CPU_X86_LEVELS`, `…V3`, `…V4` are defined and
+two extra PERMANOVA objects are built with `-march=x86-64-v3` (AVX2) and
+`-march=x86-64-v4` (AVX512).
+
+## The `skbb_cpu_tu` macro
+
+`src/Makefile:139-146` defines one canned recipe that emits **three** rules per
+translation unit:
+
+```make
+$(eval $(call skbb_cpu_tu,<stem>,<source>,<header deps>,<extra flags>))
+#   -> <stem>.o        via $(CXX)       $(CXXFLAGS)
+#   -> <stem>.wasm.o   via $(WASM_CXX)  $(WASM_CXXFLAGS)
+#   -> <stem>.inmem.o  via $(INMEM_CXX) $(INMEM_CXXFLAGS)
+```
+
+Use it for any source that is identical across the three flavors. Asymmetric
+rules stay explicit: the x86 dispatch objects and the GPU objects are
+native-only; `ordination/linalg_backend_lapacke.cpp` (native) vs
+`linalg_backend_eigen.cpp` (wasm + inmem) are different sources under different
+stems.
+
+After adding a `skbb_cpu_tu` line you must also append the object to the three
+object lists — `SKBB_OBJS` (`src/Makefile`), `WASM_OBJS`
+(`src/wasm/emscripten_build.mk`), `INMEM_OBJS` (`src/inmem_build.mk`). They are
+maintained by hand and nothing checks that they agree.
+
+## Generated sources
+
+Produced by the Python generators at build time; **not committed**; wiped by
+`make -C src clean`. See [`codegen.md`](codegen.md).
+
+| Generated file | Recipe |
+|---|---|
+| `src/permanova_cpu.cpp` | `generate_permanova_dyn.py cpu direct` |
+| `src/permanova_cpu_x86_v{3,4}.cpp` | `generate_permanova_dyn.py cpu_x86_v{3,4} direct` |
+| `src/permanova_acc_{nv,amd}.cpp` | `… acc_{nv,amd} indirect` (dlopen stubs) |
+| `src/permanova_dyn_acc_{nv,amd}.h` | `… acc_{nv,amd} api_h` |
+| `src/permanova_dyn_acc_nv.{cu,cpp}` / `…amd.{hip,cpp}` | `… acc_* api` (the plugin body) |
+| `src/skbb_accapi_cpu.cpp` and the `skbb_accapi_*` family | `generate_skbb_accapi.py` with the same four methods |
+
+`src/tests/wasm/expected/{permanova,pcoa}_expected.h` are also generated — by
+*native* binaries — and are `.gitignore`d on purpose.
+
+## Build outputs
+
+```
+src/libskbb_cpu.a      # static, all internal objects; tests link this
+src/libskbb.so         # public shared library = extern objects + libskbb_cpu.a + BLAS
+src/libskbb_acc_nv.so  # optional NVIDIA plugin, loaded via dlopen at runtime
+src/libskbb_acc_amd.so # optional AMD plugin
+src/libskbb_wasm.a     # WASM flavor
+src/libskbb_inmem.a    # native-Eigen flavor
+src/test_{pcoa,permanova}.exe
+api_tests/test_{distance,ordination}.exe
+```
+
+Note the GPU plugins are **not linked** into `libskbb.so`. `libskbb.so` contains
+stub functions that `dlopen("libskbb_acc_nv.so")` on first use; if the file is
+absent, `acc_found_gpu()` returns false and the CPU path is taken. That is why
+a GPU-capable build still runs on a GPU-less machine.
+
+## WASM specifics
+
+* `scripts/fetch_eigen.sh` downloads Eigen **3.4.0** (SHA-pinned) into
+  `.wasm-cache/eigen/include/`. Idempotent; `FORCE_REFRESH=1` re-fetches.
+  `scripts/test_eigen_wasm.sh` validates the cache.
+* Flags: `-DSKBB_WASM=1 -DSKBB_BLAS_BACKEND_EIGEN=1 -DNOGPU=1 -fno-exceptions
+  -Wno-unknown-pragmas`. No `-fopenmp`, no `-pthread`.
+  `-Wno-unknown-pragmas` is what lets the `#pragma omp` lines in shared sources
+  compile away silently.
+* Public headers refer to themselves as `scikit-bio-binaries/<x>.h`; both WASM
+  test Makefiles stage copies into a temporary include tree
+  (`.wasm-test-include/`, `api_tests/wasm/include/`) to satisfy that.
+* Requires `emcc/em++/emar` on `PATH` (emsdk ≥ 5.0.3) and node ≥ 18 to run.
+
+## `clean` gotchas
+
+* `make -C src clean` runs `rm -f *.cpp *.hpp *.h *.cu` **in `src/`**. Safe only
+  because every such file there is generated. Do not add hand-written sources at
+  that level.
+* It does **not** remove `*.hip` (the HIP plugin body), nor the WASM/inmem
+  outputs (`wasm_clean` / `inmem_clean` handle those), nor
+  `src/tests/wasm/expected/`.
+* `clean_install` removes the listed libs and headers from `$PREFIX` — same
+  unset-`PREFIX` hazard as `install`.
+
+## CI (`.github/workflows/main.yml`)
+
+Two jobs:
+
+* **build-and-test** — matrix `ubuntu-latest`, `macos-latest`, `ubuntu-24.04-arm`.
+  Conda-provisioned compilers + `libcblas liblapacke blas-devel`. On `linux-64`
+  only, installs `cuda-compiler` and sets `NV_CUDA=Y` so the CUDA plugin is
+  *compiled* (never executed — no GPU on the runner). Tests run with
+  `OMP_NUM_THREADS=3` ("a weird number to potentially catch bugs").
+* **build-and-test-wasm** — emsdk 5.0.3 + node 20 + a *native* gcc/BLAS toolchain
+  (the WASM tests compare against expected values produced by a native binary).
+  Runs with `NOGPU=1 BLASLIB="-llapacke -lopenblas"`.
+
+`macos-13` was dropped from the matrix (runners retired).

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,116 @@
+# Code style and change discipline
+
+This repository is upstream `scikit-bio/scikit-bio-binaries`, maintained by
+Igor Sfiligoi (@sfiligoi). We contribute through PRs from a fork. **Conformance
+to what is already there beats our taste**, and every line we touch is a line the
+maintainer has to review.
+
+## There is no formatter — so churn is never free
+
+No `.clang-format`, no `make format`, no format check in CI. Nothing will
+reformat a file back, and nothing enforces a house style. Therefore:
+
+* **Never reformat, re-indent, re-wrap, or re-order anything you are not
+  functionally changing.** A whitespace-only hunk is pure reviewer cost.
+* Do not fix typos in comments or identifiers you are not otherwise editing.
+  The codebase contains `permutted`, `avaialble`, `cpecific`, `trashing`,
+  `unction`, `n_eighs` (for eigenvalues), `skbio_bins` in log strings. They are
+  harmless and some are load-bearing (`n_eighs` is in the public API).
+* Do not "modernize" (`typedef`→`using`, `malloc`→`new`, raw loops→algorithms)
+  outside the scope of the task.
+
+## Match the file, not a global rule
+
+Indentation genuinely varies by file and there is no correct answer other than
+the surrounding code:
+
+| File | Indent |
+|---|---|
+| `src/util/skbb_detect_acc.cpp` | 1 space |
+| `src/distance/permanova.cpp`, `src/ordination/principal_coordinate_analysis.cpp` | 2 spaces, with tabs in some continuation lines |
+| `src/ordination/linalg_backend_*.cpp`, `src/util/portable_shuffle.hpp`, `src/tests/wasm/*` | 4 spaces |
+| generated `.cpp`/`.h` | whatever the generator emits — never hand-edit |
+
+Other conventions that are consistent and should be followed:
+
+* BSD 3-Clause header block at the top of every source file. Files derived from
+  UniFrac carry both copyright lines (`2016-2025, UniFrac development team` and
+  `2025--, scikit-bio development team`); new files carry only the latter.
+* `template<class T>`, not `template<typename T>`.
+* Type parameter names: `TFloat` (float/double), `TNum` (numeric+bool),
+  `TReal`/`TRealIn` in the ordination code.
+* Implementation functions carry the `_T` suffix — **this is parsed by the code
+  generators**, see [`codegen.md`](codegen.md).
+* `snake_case` for functions and variables; `n_dims`, `n_perm`, `n_eighs`,
+  `n_groups` for sizes.
+* `} else {` on one line; no `using namespace`.
+* Public headers are C-compatible: `EXTERN` macro, `#include <stdbool.h>` under
+  C, no C++ types in signatures.
+* Memory: both `new[]/delete[]` and `malloc/free` are in use, sometimes in the
+  same file. Match the function you are editing rather than converting it.
+
+## Comments
+
+The existing comments are short and explain **why**, not what:
+
+```cpp
+for (uint32_t col=row+1; col < n_dims; col++) { // diagonal is always zero
+// Use full precision for intermediate compute, to minimize accumulation errors
+// speculatively read, we will likely use it at least in one of the ifs
+```
+
+Write comments that will still be true and useful to someone reading this file in
+two years with no knowledge of the change that introduced them.
+
+**Long comments are justified only when they encode a constraint that would
+otherwise be rediscovered the hard way.** Good examples already in the tree:
+
+* `util/portable_shuffle.hpp` — why `std::shuffle` is banned.
+* `linalg_backend.hpp` — the `svd_no` stride contract.
+* `permanova_dyn_impl.hpp:64-70` — why the `#error` exists instead of a default.
+* `Makefile:5-9` — why `.NOTPARALLEL` is required.
+
+**Do not narrate the work.** These are the failure mode, and the tree already
+contains examples that have gone stale:
+
+* `"Stage 3: …"`, `"Stage 6: …"` — PR-plan numbering in source files.
+* `"per reviewer guidance"`, `"(see PR #12 discussion)"` — review-round context.
+* `"Exact behaviour of the pre-refactor principal_coordinate_analysis.cpp"` —
+  meaningless once nobody remembers the refactor.
+* `generate_permanova_expected.cpp:15-25` — describes a policy (headers checked
+  in, a `wasm_regen_*` make target) that was **reversed during review**; the
+  comment now actively misleads. See
+  [`known-issues.md`](known-issues.md#stale-comments-that-contradict-the-code).
+
+That context belongs in the commit message and the PR description, where it is
+timestamped and does not rot in place.
+
+## What the maintainer has actually pushed back on
+
+From the review history — treat these as standing requirements:
+
+1. **Duplicated build infrastructure.** On PR #12: *"Most of this file looks
+   exactly like the Makefile. Couldn't we consolidate the two, so we do not need
+   to maintain two copies? Especially as/when we add additional functionality."*
+   → produced the `skbb_cpu_tu` canned recipe. Add a new translation unit in
+   **one** place; do not copy a rule between `src/Makefile`,
+   `wasm/emscripten_build.mk` and `inmem_build.mk`.
+2. **Committing generated artifacts.** On PR #12: *"Why do we check in the
+   expected files, if they have been dynamically generated?"* → the WASM
+   expected-value headers are now `.gitignore`d and regenerated on demand.
+   Generated output does not go in git.
+3. **Complexity is tolerated but noticed.** On the GPU/x86 dispatch rules:
+   *"A bit complex, but cannot think of a better way."* Prefer the boring
+   solution; if a change makes the build or dispatch harder to follow, say so in
+   the PR description and explain why the simpler option does not work.
+
+## Commits and PRs
+
+* Stage explicit paths — never `git add -A` / `git add .` / `git commit -a`. The
+  tree fills with build artifacts (`*.o`, `*.a`, generated `*.cpp`) that are not
+  all gitignored, and they will end up in the commit.
+* Confirm before pushing: `git status`, then
+  `git diff --name-status <base>...HEAD`.
+* Keep the diff to the task. Unrelated fixes — including the entries in
+  [`known-issues.md`](known-issues.md) — go in their own commit with their own
+  test.

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -1,0 +1,110 @@
+# Code generation (`src/tools/`)
+
+Every runtime-dispatched kernel exists once in source and is mechanically
+expanded into four different shapes by a ~240-line Python line-scanner. This is
+the least obvious machinery in the repo; read this before touching
+`permanova_dyn_impl.hpp` or `skbb_accapi_impl.hpp`.
+
+## The pieces
+
+```
+src/tools/skbb_generate_helper.py     # the engine: print_header() + print_body()
+src/tools/generate_permanova_dyn.py   # driver, reads distance/permanova_dyn_impl.hpp
+src/tools/generate_skbb_accapi.py     # driver, reads util/skbb_accapi_impl.hpp
+```
+
+Invocation (from `src/`, always redirected to a file by the Makefile):
+
+```sh
+./tools/generate_permanova_dyn.py <variant> <method> > <out>
+#   variant: cpu | cpu_x86_v3 | cpu_x86_v4 | acc_nv | acc_amd   -> namespace skbb_<variant>
+#   method:  direct | indirect | api | api_h
+```
+
+## The `_T` contract
+
+`print_body()` (`skbb_generate_helper.py:189`) walks the input header line by
+line and emits a wrapper for **every function whose declaration line starts with
+`static inline ` and contains `_T(`**. Everything else is ignored.
+
+```cpp
+static inline int pmn_get_max_parallelism_T() { … }          // -> no-arg wrapper
+
+template<class TFloat>
+static inline void pmn_f_stat_sW_T(                          // -> one wrapper per type
+        const uint32_t n_dims,
+        const TFloat * mat,
+        …) { … }
+```
+
+Rules the parser enforces (or silently assumes):
+
+* The wrapper name is the text between the third whitespace-separated token and
+  `_T(`. The return type is the *second* token (`static inline <type> <name>_T`).
+* **A templated (multi-argument) function must return `void`.** Anything else
+  raises. Only the zero-argument form may return a value.
+* Type expansion is driven by substring match on the argument list:
+  `TFloat` → `{float, double}`; `TNum` → `{float, double, uint64_t, uint32_t, bool}`.
+  Both are textually replaced by `patch_type()`.
+* Argument parsing consumes lines until it sees `") "` — i.e. **the closing paren
+  of the parameter list must be followed by a space** (`…, TFloat *out) {`).
+  A `)` at end of line, or `){`, breaks the scan.
+* The argument *name* is `split()[-1].split('*')[-1]`, so
+  `TNum** buf_device` works but a name-less parameter or an array-suffix
+  declarator (`TFloat out[]`) will not.
+
+Follow the existing formatting exactly. The parser is positional, not a C++
+parser, and it fails by emitting subtly wrong code rather than erroring.
+
+## The four methods
+
+Given `void foo_T(const uint32_t n, TFloat *x)` and variant `acc_nv`
+(namespace `skbb_acc_nv`):
+
+| method | Emits | Used for |
+|---|---|---|
+| `direct` | `template<> void skbb_cpu::foo(uint32_t n, float *x) { foo_T(n, x); }` — plus `#include`s of both the declaration header and the impl header. | CPU variants, where the kernel is compiled by the same compiler into the same library. `permanova_cpu.cpp`, `permanova_cpu_x86_v{3,4}.cpp`, `skbb_accapi_cpu.cpp`. |
+| `api_h` | `extern "C" void skbb_acc_nv_foo_float(uint32_t n, float *x);` | The flat C header shared by the plugin and its caller (`permanova_dyn_acc_nv.h`). Emits `#include <stdbool.h>` / `<stdint.h>` first. |
+| `api` | `void skbb_acc_nv_foo_float(uint32_t n, float *x) { foo_T(n, x); }` | The **plugin body** — compiled by `nvcc`/`hipcc`/`nvc++`/`amdclang++` into `libskbb_acc_nv.so`. |
+| `indirect` | a static `dl_…` function pointer, plus `template<> void skbb_acc_nv::foo(…) { cond_dl_load("skbb_acc_nv_foo_float", &dl_…); (*dl_…)(n, x); }` | The **stub** linked into `libskbb.so`. Also emits `static const char *dl_get_lib_name() { return "libskbb_acc_nv.so"; }` and `#include "util/skbb_dl.cpp"`. |
+
+Special case worth knowing: in `indirect` mode a `bool`-returning no-arg function
+whose name contains `found_gpu` gets an extra first line
+(`skbb_generate_helper.py:57-59`):
+
+```cpp
+if (!dl_load_check()) return false; /* shlib not found */
+```
+
+That single hook is what makes a GPU-enabled `libskbb.so` degrade gracefully to
+CPU when the plugin `.so` is missing. Every other `indirect` function calls
+`cond_dl_load()`, which `exit(1)`s if `dlopen`/`dlsym` fails — so `acc_found_gpu()`
+must always be the first plugin call made.
+
+## Adding a dispatched function
+
+1. Write `static inline … myfunc_T(…)` in `permanova_dyn_impl.hpp` (or
+   `skbb_accapi_impl.hpp`), guarded by the `#if defined(SKBB_CPU) / SKBB_CUDA /
+   SKBB_HIP / OMPGPU / _OPENACC` ladder as appropriate.
+2. Declare `myfunc` in the matching `*_dyn.hpp` / `skbb_accapi.hpp` inside
+   `namespace SKBB_ACC_NM { … }` — template declaration only, **no definition**.
+3. Nothing else. The Makefile rules already regenerate all variants because the
+   generated `.cpp`/`.h` depend on the impl header.
+4. Call it from the orchestration layer through the right namespace, guarded by
+   the runtime dispatch (`src/distance/permanova.cpp:171-225` is the model).
+
+If the new function is called on a device pointer, remember that on CUDA/HIP the
+`acc_*_buf` primitives return a *distinct device pointer*, while on
+OpenACC/OpenMP-target they return the host pointer with a mapping attached. Code
+must work with both — see [`acceleration-dispatch.md`](acceleration-dispatch.md).
+
+## Debugging generated code
+
+The generated files are ordinary text in `src/`. To inspect without a full build:
+
+```sh
+cd src && ./tools/generate_permanova_dyn.py acc_nv indirect | less
+```
+
+They carry a `// Generated from … // Do not edit by hand` banner. Editing them
+is pointless — the next `make` regenerates them, and `make clean` deletes them.

--- a/docs/determinism-and-numerics.md
+++ b/docs/determinism-and-numerics.md
@@ -1,0 +1,98 @@
+# Determinism and numerics
+
+This library's reproducibility guarantees are narrower than they look. Read this
+before changing anything that touches RNG, thread counts, chunk sizes, or the
+order of floating-point accumulation.
+
+## The RNG model
+
+`src/util/rand.{hpp,cpp}`. `skbb::TRAND` is `std::mt19937` — chosen because the
+C++ standard fully specifies its state and output sequence, so it is identical
+across libstdc++, libc++, and emscripten.
+
+Two levels:
+
+* **Global generator** — one file-static `std::mt19937`, seeded by
+  `skbb_set_random_seed()`. Used whenever a `seed` argument is `< 0`.
+  Process-wide mutable state: not thread-safe, and results depend on how many
+  random numbers earlier calls consumed.
+* **`RandomGeneratorArray(size, seed)`** — an array of independent generators,
+  one per parallel slot. `rga_init` (rand.cpp:28) draws `size` seeds *in order*
+  from either a locally-seeded generator (`seed >= 0`) or the global one
+  (`seed < 0`), then seeds each element. This is what makes threaded PERMANOVA
+  deterministic: slot *i* always gets the same stream regardless of scheduling.
+
+## `portable_shuffle`, and why `std::shuffle` is banned
+
+`src/util/portable_shuffle.hpp`. `std::shuffle` delegates to
+`std::uniform_int_distribution`, whose mapping from RNG output to a bounded
+integer is **implementation-defined**; libstdc++, libc++ and MSVC each choose
+differently. Seeded results would then differ between the native gcc build and
+the emscripten build.
+
+The replacement is a textbook rejection-method Fisher-Yates:
+
+```
+threshold = (2^32 - bound) % bound
+do { r = rng(); } while (r < threshold);
+return r % bound;
+```
+
+Unbiased and byte-identical everywhere. **Do not reintroduce `std::shuffle`,
+`std::uniform_int_distribution`, or any `<random>` distribution on a hot,
+reproducibility-sensitive path.** (`std::normal_distribution` *is* used in
+FSVD's Halko projection — see the caveat below.)
+
+## What is guaranteed, and what is not
+
+| Property | Guaranteed? |
+|---|---|
+| Same build, same inputs, same seed, same thread count → identical output | **Yes.** The WASM tests assert bit-equality on a repeat call. |
+| Native vs WASM PERMANOVA `fstat`/`pvalue` at a fixed seed | **Yes, bit-identical** — same arithmetic, same mt19937, portable shuffle, and `pmn_get_max_parallelism()` returns 32 under WASM to match native single-thread. |
+| Same seed across **different `OMP_NUM_THREADS`** | **No.** `PERM_CHUNK = 2·threads·16` changes `step_perms`, which changes how many generators are created and how permutations are chunked. |
+| Native vs WASM PCoA | Approximately: 1e-6 on eigenvalues/proportions, 1e-3 on coordinates (sign-adjusted). LAPACK `dgesvd` and Eigen `BDCSVD` bidiagonalize differently. Observed drift in the shipped cases is ~1e-15; the headroom is for larger/ill-conditioned inputs. |
+| FSVD seeded results across toolchains | **No.** `std::normal_distribution` has the same implementation-defined problem as `uniform_int_distribution`. The WASM PCoA test therefore compares with tolerances, not bit-equality. |
+| fp32 vs fp64 agreement | Only to fp32 precision. Note accumulators are `double` in both PERMANOVA kernels regardless of `TFloat`. |
+| Bit-stability across compiler/optimization changes | **No.** `-ffast-math` is on for the native build, permitting reassociation. |
+
+## Things that silently change seeded results
+
+Treat any change to these as an API-visible change and regenerate the WASM
+expected values (see [`testing.md`](testing.md)):
+
+1. `pmn_get_max_parallelism()` for any backend.
+2. `NBLOCK` (16) or the tail decomposition in `pmn_f_stat_sW_cpu`.
+3. The number, order, or seeding of `RandomGeneratorArray` elements.
+4. Where `portable_shuffle` is called, or how many draws it makes.
+5. Choosing a different x86 level for `pmn_get_max_parallelism` (currently
+   deliberately always `skbb_cpu::`, permanova.cpp:97).
+6. The order of the permutation loop / whether rows are reset between chunks.
+
+The `#error` in `pmn_get_max_parallelism_T` for non-OpenMP non-WASM CPU builds
+exists for exactly this reason: an arbitrary fallback chunk size would silently
+change every seeded p-value.
+
+## Precision choices in the kernels
+
+* PERMANOVA accumulates `s_W` in `double` even for the `float` instantiation
+  ("Use full precision for intermediate compute, to minimize accumulation
+  errors"), at both the per-row and per-tile level, and in the CUDA shared-memory
+  reduction. `TFloat` controls only the storage type of the distance matrix.
+* `sum_upper_square` likewise reduces into a `double` and casts at the end.
+* PCoA centering accumulates row sums in `TReal` (the *output* type), so the
+  fp64→fp32 mixed path accumulates in fp32.
+* The CPU and GPU PERMANOVA kernels apply `inv_group_sizes` at different
+  granularity (per row vs per element), so their results differ in the last bits.
+
+## Seed semantics at the public API
+
+Every seeded entry point takes `int seed`:
+
+* `seed >= 0` → deterministic, self-contained: a local generator is seeded with
+  it and nothing touches global state.
+* `seed < 0` → draw from the library-global generator (settable with
+  `skbb_set_random_seed`). Reproducible only if you control every prior call in
+  the process.
+
+Note `skbb_set_random_seed` takes `unsigned int` while the per-call `seed` is
+`int`, so the per-call seed space is half as large.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,157 @@
+# Known issues and latent hazards
+
+Findings from a full read of the tree. Each entry says how it was established —
+**verified** (reproduced here), **read** (from the source, not executed), or
+**latent** (works today, will break under a plausible change).
+
+Nothing in this file has been fixed. Do not "clean up" any of it as a drive-by
+inside an unrelated change — raise it, get agreement, fix it in its own commit
+with a test.
+
+---
+
+## PERMANOVA: NBLOCK tail uses the wrong grouping rows
+
+**Verified.** `src/distance/permanova_dyn_impl.hpp:186-224`.
+
+`pmn_f_stat_sW_cpu` builds one array of 16 grouping-row pointers per 16-permutation
+block, then decomposes a partial block greedily as 8+4+2+1. The sub-block calls
+advance the *output* offset (`gblock2`) but always pass the **same**
+`grouping_arr` base, so every sub-block after the first re-reads grouping rows
+`gblock+0…` while writing to `group_sWs[gblock2…]`:
+
+```cpp
+uint32_t gblock2=gblock;
+if ((gblock2+(8-1))<n_grouping_dims) {
+  pmn_f_stat_sW_block<TFloat,8>(n_dims,mat, grouping_arr, …, group_sWs+gblock2);
+  gblock2+=8;
+}
+if ((gblock2+(4-1))<n_grouping_dims) {
+  pmn_f_stat_sW_block<TFloat,4>(n_dims,mat, grouping_arr, …, group_sWs+gblock2);
+  //                                        ^^^^^^^^^^^^ still rows gblock+0..3
+```
+
+Effect: the affected permutations get a duplicate of an earlier permutation's
+`s_W` instead of their own. The p-value is then computed from a permutation
+distribution containing duplicates. When the *first* chunk is the partial one
+(i.e. `n_perm+1 < PERM_CHUNK`), the duplicated row can be permutation 0 — the
+**unpermuted** statistic — which biases `p` upward.
+
+Trigger condition, exactly: **`(n_perm+1) mod 16 ∉ {0, 1, 2, 4, 8}`**, i.e. 11
+of every 16 values of `n_perm`. It does not depend on the thread count —
+`PERM_CHUNK = 2·OMP_NUM_THREADS·16` is always a multiple of 16, so every chunk's
+size is congruent to `n_perm+1` mod 16.
+
+Every `n_perm` used anywhere in the test suites lands on a safe residue, which is
+why this was never caught: 999 → 8, 99 → 4, 199 → 8, 499 → 4. `n_perm = 9`
+(→ 10) and `n_perm = 1000` (→ 9) both trigger it.
+
+Reproduction: a 2×2 distance matrix makes the expected `s_W` per grouping row
+trivially known (1.0 if the two samples share a group, else 0.0). Pass 10 rows —
+eight `{0,0}` then two `{0,1}` — and rows 8 and 9 come back as 1.0:
+
+```
+row 7  grouping {0,0}  s_W got 1.0  want 1.0  ok
+row 8  grouping {0,1}  s_W got 1.0  want 0.0  WRONG
+row 9  grouping {0,1}  s_W got 1.0  want 0.0  WRONG
+```
+
+Full reproducer in the tracking issue.
+
+Likely fix: pass `grouping_arr + (gblock2 - gblock)`. Any fix changes seeded
+p-values for the affected `n_perm` values, so the WASM expected headers must be
+regenerated — see [`determinism-and-numerics.md`](determinism-and-numerics.md#things-that-silently-change-seeded-results).
+
+Related, same function: `grouping_arr[i] = groupings + (gblock+i)*n_dims` is
+computed for all 16 `i` even when `gblock+i >= n_grouping_dims`. The out-of-range
+pointers are never dereferenced, but forming them is UB.
+
+## PERMANOVA GPU: `permutted_sWs` device buffer is one element short
+
+**Read** (no GPU available here to execute).
+`src/distance/permanova.cpp:135, 146, 232, 241`.
+
+The host buffer holds `n_perm+1` statistics (allocated in `permanova_all_T` as
+`permutted_fstats[n_perm+1]`, and the loop writes indices `0..n_perm`), but the
+device allocation and copy-back both use `n_perm`:
+
+```cpp
+skbb_acc_nv::acc_create_buf(permutted_sWs, &permutted_sWs_device, n_perm);
+…
+skbb_acc_nv::acc_copyout_buf(permutted_sWs, permutted_sWs_device, n_perm);
+```
+
+Under CUDA/HIP that is a one-element device heap overflow on write, plus the last
+permutation's `s_W` is never copied back (the host slot keeps whatever
+`new TFloat[]` left there). Under OpenACC/OpenMP-target the last element is
+outside the mapping.
+
+## `api_tests` exit code masks earlier failures
+
+**Verified by reading.** `api_tests/test_distance.c:124`,
+`api_tests/test_ordination.c:436`.
+
+Both `main()`s end with `return failed ? 1 : 0;`, but `failed` is reset to `0` at
+the top of every test function. A failure in an earlier function is therefore
+invisible to the exit code if a later one passes. `global_failed` is maintained
+for the printed summary but never used for the return value. CI's `make test`
+consequently cannot fail on those cases.
+
+## Test asserts the wrong variable after an fp32 call
+
+**Verified by reading.** `src/tests/test_permanova.cpp:54-59` (and the same
+pattern at `api_tests/test_distance.c:60-65`).
+
+```cpp
+skbb::permanova(n_samples, matrix_fp32, grouping_equal, 999,
+                rand_seed_invalid, stat_fp32, pvalue_fp32);
+ASSERT(fabs(stat_fp64 - exp_stat) < 0.00001);      // fp64, from the PREVIOUS call
+ASSERT(fabs(pvalue_fp64 - exp_pvalue) < 0.05);
+```
+
+The fp32 result of that call is never checked.
+
+## Stale comments that contradict the code
+
+**Verified by reading.** `src/tests/wasm/generate_permanova_expected.cpp:15-25`
+says the generated header "is checked into the repo so the WASM test is
+hermetic" and tells you to regenerate with
+`make -C src wasm_regen_permanova_expected`. Both are false: the headers are
+`.gitignore`d (that was the maintainer's PR #12 request) and no such make target
+exists. `src/wasm/emscripten_build.mk:120-125` states the opposite, correctly.
+
+This is the failure mode the comment rules in `CLAUDE.md` are about: the comment
+described the state of one pull request rather than the code.
+
+## Unguarded `PREFIX` in `install` / `clean_install`
+
+**Read.** `src/Makefile:394-403`. `PREFIX` falls back to `CONDA_PREFIX`; if both
+are unset the recipe runs `mkdir -p /lib` and copies there. `install_inmem` in
+`src/inmem_build.mk:70-74` has the guard the others lack.
+
+## `ordination.h` documents the output shape ambiguously
+
+**Read.** `src/extern/ordination.h:104` describes `samples` as
+"Matrix of size (n_eighs x n_dims)" while the adjacent prose says "row-indexed by
+the sample id". The code produces `n_dims` rows of `n_eighs` values. The element
+count is identical, so nothing breaks — but a caller indexing
+`samples[axis*n_dims + sample]` gets garbage.
+
+## Latent build fragilities
+
+* `make -C src clean` runs `rm -f *.cpp *.hpp *.h *.cu` in `src/`. It is safe
+  only because every such file there is generated. It also misses `*.hip`
+  (generated by the AMD HIP path).
+* `test_permanova.exe` links `libskbb_cpu.a` **without** `$(BLASLIB)`. It works
+  because static-archive linking pulls only the objects it needs and PERMANOVA
+  touches no BLAS. Any new dependency from `distance/` onto `ordination/` breaks
+  that link.
+* `SKBB_OBJS`, `WASM_OBJS` and `INMEM_OBJS` are three hand-maintained lists of
+  the same translation units. Nothing checks that they agree.
+* No top-level `inmem_static` target; it is reachable only as
+  `make -C src inmem_static`.
+* `src/util/skbb_dl.cpp:31,74` tests `SKBB_GPU_INFO[0] == 'Y'` while
+  `skbb_detect_acc.cpp` uses a negative-list convention, so `SKBB_GPU_INFO=y`
+  enables one set of messages and not the other.
+* CUDA/HIP failures `throw std::runtime_error` through an `extern "C"` boundary;
+  the public API has no error channel and nothing catches them.

--- a/docs/pcoa-fsvd.md
+++ b/docs/pcoa-fsvd.md
@@ -1,0 +1,130 @@
+# PCoA and FSVD
+
+Files: `src/ordination/principal_coordinate_analysis.{hpp,cpp}`,
+`linalg_backend.hpp` + `linalg_backend_{lapacke,eigen}.cpp`.
+Public entries: `skbb_center_distance_matrix_*`, `skbb_fsvd_inplace_*`,
+`skbb_pcoa_fsvd_*`.
+
+## Pipeline
+
+```
+mat (n×n distances)
+  │  mat_to_centered            Legendre & Legendre 1998, eq. 9.20 + 9.21
+  ▼
+centered (n×n)  ── trace kept for proportion_explained
+  │  find_eigens_fast           Halko et al. 2011 randomized SVD ("FSVD")
+  ▼
+eigenvalues[k], eigenvectors (n×k)
+  │  scale each axis by sqrt(eigenvalue)
+  ▼
+samples (n×k), proportion_explained[k] = eigenvalues / trace(centered)
+```
+
+## Centering (`mat_to_centered`)
+
+Two passes, both OpenMP-parallel over rows:
+
+1. `E_matrix_means` (line 34) — `E[i,j] = -0.5 · D[i,j]²`, accumulating row sums
+   and the global sum in the same pass. `row_means[i] = rowsum/n`,
+   `global_mean = (globalsum/n)/n`.
+2. `F_matrix_inplace` (line 133) — `F[i,j] = E[i,j] - row_mean[i] - row_mean[j]
+   + global_mean`, tiled 512×512 to keep `row_means` hot.
+
+Since the matrix is symmetric, column means are row means — that identity is why
+only one mean vector is computed.
+
+`mat` and `centered` may alias (in-place). The `E_matrix_means` `#ifdef __AVX2__`
+/ `__AVX__` 8×/4× unrolled variants are compile-time only and, with the default
+flags (no `-march`), the scalar tail loop is what actually runs.
+
+The mixed overload `mat_to_centered(n, const double*, float*)` reads fp64 and
+writes fp32, computing means in fp32 (`TReal` = the *output* type). That is the
+`skbb_center_distance_matrix_fp64_to_fp32` path.
+
+## FSVD (`find_eigens_fast_T`, line 360)
+
+Randomized eigendecomposition of the (symmetric, PSD-ish) centered matrix.
+With `k = n_eighs + 2`:
+
+| Step | Code | Shapes |
+|---|---|---|
+| 1. Random projection with one power iteration | `centered_randomize_T` (line 211) | `G` ~ N(0,1), n×k. `H = [A·G ; A·A·(A·G)]`, n×2k |
+| 2. Orthonormalize | `QR` class (line 254) → `qr_inplace` | `Q` = n×qcols, `qcols = min(n, 2k)`; H buffer becomes Q |
+| 3. Project | `qdot_r_sq` → `gemm_nn` | `T = A·Q`, n×qcols (uses `Aᵀ == A`) |
+| 4. SVD | `svd_it_T` → `svd_no` | singular values → `S`; `Vᵀ` overwrites `T` |
+| 5. Lift back | `qdot_l_sq` | `U = Q·V`, n×qcols, reusing the `T` buffer |
+| 6. Truncate + transpose | `transpose_T` | first `n_eighs` values/columns → outputs |
+
+The power iteration is fixed at **one** pass (`A·A·(A·G)` — three gemms). There
+is no convergence check and no oversampling knob beyond the hard-coded `+2`.
+
+Two ownership subtleties: `QR` takes ownership of the `H` malloc and `free`s it
+in its destructor; `Ut` then takes ownership of the `T` malloc. Both are raw
+`malloc`/`free` interleaved with `new[]`/`delete[]` elsewhere in the file — match
+whatever the surrounding function already uses.
+
+`qr_i_T` and `svd_it_T` failures call `exit(1)` after printing to stderr
+("should never fail"). There is no error return to the caller.
+
+## Linear-algebra backend
+
+`skbb::linalg` is deliberately three functions, not a BLAS facade
+(`linalg_backend.hpp`):
+
+```cpp
+void gemm_nn(m, n, k, A, B, C);         // C = A·B, column-major, alpha=1 beta=0
+int  qr_inplace(rows, cols, H, &qcols); // H -> thin Q (rows × min(rows,cols))
+int  svd_no(rows, cols, T, S);          // LAPACK jobu='N', jobvt='O'
+```
+
+Compile-time selection: `-DSKBB_BLAS_BACKEND_EIGEN=1` picks
+`linalg_backend_eigen.cpp` (WASM + inmem); otherwise the native build compiles
+`linalg_backend_lapacke.cpp` (`cblas_?gemm`, `LAPACKE_?geqrf`+`?orgqr`,
+`LAPACKE_?gesvd`). Both are compiled under the object stem
+`ord_linalg_backend*.o`; only one is linked into a given artifact.
+
+**The `svd_no` output layout contract is the sharp edge.** `Vᵀ` occupies the
+first `k = min(rows,cols)` rows of the `rows × cols` column-major buffer, so it
+must be read with stride `rows`, not packed. Rows `[k, rows)` are undefined.
+`transpose_sq_st_T(qr_obj.cols, qr_obj.rows, T, W)` exists exactly to honour
+that stride. The Eigen implementation reproduces the layout by hand
+(`linalg_backend_eigen.cpp:104-110`) rather than inheriting it.
+
+Everything here is **column-major** ("FORTRAN-style ColOrder"), while the
+public matrices and the final outputs are row-major. The transposes at the
+boundary are not redundant.
+
+## Output layouts and sizes
+
+| Buffer | Size | Layout |
+|---|---|---|
+| `mat` / `centered` | `n*n` | row-major (symmetric, so also column-major) |
+| `eigenvalues` | `n_eighs` | descending |
+| `eigenvectors` (from `skbb_fsvd_inplace_*`) | `n * n_eighs` | **row-major, n rows × n_eighs cols** |
+| `samples` (from `skbb_pcoa_fsvd_*`) | `n * n_eighs` | **row-major, one row per sample** |
+| `proportion_explained` | `n_eighs` | `eigenvalue / trace(centered)` |
+
+The header comment says "Matrix of size (n_eighs x n_dims)" while the prose says
+"row-indexed by the sample id"; the code (`transpose_T(n_dims, n_eighs, …)` and
+the scaling loop at line 575) is unambiguous: **n rows of n_eighs values**. Total
+element count is the same either way, which is why the tests never caught the
+wording.
+
+## Constraints and gotchas
+
+* `n_eighs <= n_dims` is required (`eigenvalues[i] = S[i]` for `i < n_eighs`,
+  and `S` only holds `min(n, 2k)` meaningful values). Not checked.
+* **`proportion_explained` is used as scratch** inside `pcoa_T` (line 567) to
+  hold `sqrt(eigenvalues)` before being overwritten with the real values. The
+  three output buffers must not alias each other.
+* `samples` **is** the eigenvector buffer during compute (line 531) — that is
+  why it needs `n*n_eighs` elements even before scaling.
+* `skbb_fsvd_inplace_*` and `skbb_pcoa_fsvd_inplace_*` destroy their input
+  buffer. The `NewCentered` / `InPlaceCentered` pair (lines 441-484) is the only
+  difference between the two families: one allocates an `n*n` scratch, the other
+  reuses `mat`.
+* Eigenvectors are **not normalized to unit length** on output (documented in
+  the public header) and their sign is arbitrary — compare up to sign.
+* Seeding: `seed < 0` means "draw from the library-global generator", which is
+  process-shared mutable state. See
+  [`determinism-and-numerics.md`](determinism-and-numerics.md).

--- a/docs/permanova.md
+++ b/docs/permanova.md
@@ -1,0 +1,146 @@
+# PERMANOVA
+
+Files: `src/distance/permanova.{hpp,cpp}`, `permanova_dyn.hpp`,
+`permanova_dyn_impl.hpp`; public entry `skbb_permanova_fp{64,32}`.
+
+## The statistic
+
+Given a symmetric distance matrix `D` (n×n) and a grouping vector `g` (length n,
+values `0..n_groups-1`):
+
+```
+s_T   = ( Σ_{i<j} D[i,j]² ) / n                       # total sum of squares
+s_W   = Σ_{i<j, g[i]==g[j]} D[i,j]² / |group(g[i])|   # within-group
+s_A   = s_T - s_W                                     # between-group
+F     = ( s_A / (n_groups-1) ) / ( s_W / (n-n_groups) )
+```
+
+`p` is the fraction of permuted `F` values ≥ the observed `F`, with the
+standard +1 correction:
+
+```
+p = (count{ F_perm ≥ F_obs } + 1) / (n_perm + 1)
+```
+
+`n_perm == 0` yields `p = 0.0` ("just to have a deterministic value").
+
+## Call graph
+
+```
+skbb::permanova(n, mat, grouping, n_perm, seed, &fstat, &pvalue)   permanova.cpp:351/363
+└── permanova_T<TFloat>                                            permanova.cpp:321
+    ├── allocate permutted_fstats[n_perm+1]
+    ├── permanova_all_T                                            permanova.cpp:277
+    │   ├── n_groups = max(grouping)+1 ; group_sizes[n_groups]
+    │   ├── permanova_perm_fp_sW_T   -> fills permutted_fstats with s_W
+    │   ├── s_T = sum_upper_square(mat)/n                           permanova.cpp:256
+    │   └── convert s_W -> F in place
+    └── p from permutted_fstats[1..n_perm] vs permutted_fstats[0]
+```
+
+`permutted_fstats[0]` is the **unpermuted** case; indices `1..n_perm` are the
+permutations. The `s_W` array and the `F` array are the same buffer, rewritten
+in place.
+
+## Chunked permutation loop (`permanova_perm_fp_sW_T`, permanova.cpp:68)
+
+```
+PERM_CHUNK = <selected backend>::pmn_get_max_parallelism()
+step_perms = min(n_perm+1, PERM_CHUNK)
+permutted_groupings : uint32[step_perms][n]   # one grouping row per slot
+randomGenerators    : RandomGeneratorArray(step_perms, seed)
+
+all rows initialized to the original grouping (once)
+for tp in 0, step_perms, 2*step_perms, … < n_perm+1:
+    max_p = min(tp+step_perms, n_perm+1)
+    parallel for p in [tp, max_p):
+        if p != 0: portable_shuffle(row[p-tp], n, randomGenerators[p-tp])
+    <backend>::pmn_f_stat_sW(n, mat, max_p-tp, rows, inv_group_sizes, &sW[tp])
+```
+
+Three things follow from this shape and matter:
+
+* Chunking exists for **cache locality** (and for the GPU, to bound the device
+  buffer). The chunk size comes from the backend, so it is a function of
+  `OMP_NUM_THREADS` on CPU and of SM count on GPU.
+* Buffer rows are **re-shuffled from their previous permuted state**, not reset
+  to the original grouping each chunk. Still a valid permutation, but it means
+  permutation `p` depends on every chunk before it.
+* Generator `p-tp` is reused across chunks, advancing its state each time.
+  Reproducibility therefore requires an identical `step_perms`. See
+  [`determinism-and-numerics.md`](determinism-and-numerics.md).
+
+`inv_group_sizes[i] = 1/group_sizes[i]` is precomputed once so the kernel never
+divides.
+
+## `pmn_get_max_parallelism()` (permanova_dyn_impl.hpp:51)
+
+| Build | Value | Rationale |
+|---|---|---|
+| CPU + OpenMP | `2 * omp_get_max_threads() * 16` | 2× threads to amortize spawn, ×16 for the NBLOCK unroll |
+| CPU + `SKBB_WASM` | `32` | = 2·1·16, i.e. what native single-threaded gives, so seeded results match |
+| CPU, neither | `#error` | deliberate: silently picking a chunk size would silently change seeded p-values |
+| CUDA / HIP | `200 * multiProcessorCount` | ~64 blocks/SM to saturate, ×3 for load imbalance |
+| OpenACC / OMP-target | `4000` | no portable SM query |
+
+## CPU kernel (permanova_dyn_impl.hpp:114-226)
+
+Two nested pieces of blocking:
+
+* **`NBLOCK = 16`** — 16 *permutations* are evaluated in one pass over the
+  matrix, so `mat` is streamed once per 16 permutations instead of once each.
+  This is the "better CPU cache locality" work from PR #5.
+* **`TILE = 128`** — the (row, col) iteration over the strict upper triangle is
+  tiled 128×128 so `grouping_arr[i][col]` stays hot.
+
+The inner loop reads `val = mat_row[col]` unconditionally ("speculatively read,
+we will likely use it at least in one of the ifs") and then adds `val*val` to
+whichever of the 16 accumulators have `grouping[i][col] == grouping[i][row]`.
+Accumulation is in `double` even for the `float` instantiation — deliberate, to
+bound accumulation error; the `TFloat` only controls the matrix storage type.
+
+`n_grouping_dims` is decomposed greedily as 16-blocks, then 8, 4, 2, 1.
+
+> **Bug (verified).** The tail decomposition passes the *same* `grouping_arr`
+> base to every sub-block instead of advancing it, so the trailing
+> permutations of a partial chunk are computed from the wrong grouping rows.
+> Triggers when `(n_perm+1) mod 16 ∉ {0,1,2,4,8}`. See
+> [`known-issues.md`](known-issues.md#permanova-nblock-tail-uses-the-wrong-grouping-rows).
+
+## GPU kernels
+
+**CUDA/HIP** (`pmn_f_stat_sW_cuda_one`, line 231): one block per permutation,
+128 threads, `TILE = blockDim.x`. Each block stages `grouping[row]` for the tile
+into `__shared__ row_grouping[128]` (coalesced read; scattered reads then hit
+shared memory), accumulates per-thread partials in `double`, then does a 3-stage
+tree reduction (128→32→8→1) through `__shared__ double s_W_arr[128]`. Both the
+128-thread block size and the two `__shared__` arrays are hard-coded to 128 —
+they must be changed together.
+
+**OpenACC / OpenMP-target** (line 330): a much simpler `gang` over permutations
+with a `vector reduction(+:s_W)` over columns; no tiling. This is the older,
+"experimental" path.
+
+Note the arithmetic differs slightly between paths: the CPU kernel multiplies by
+`inv_group_sizes[group_idx]` once per *row* (after accumulating that row's
+contributions), while the GPU kernels multiply per *element*. Mathematically
+identical, different rounding.
+
+## Complexity and memory
+
+* Time: `O(n² · n_perm / P)` — the matrix is scanned once per permutation.
+* Extra memory: `n × step_perms` uint32 for the grouping rows,
+  `n_perm+1` TFloat for the statistics, `n_groups` TFloat for the inverses.
+  The distance matrix itself is not copied on CPU; on CUDA/HIP a full `n²`
+  device copy is made.
+
+## Caller contract (enforced nowhere — validate upstream)
+
+* `grouping` values must be **dense and 0-based**: the code takes
+  `n_groups = max(grouping)+1` and indexes `group_sizes` by label. A sparse
+  labelling like `{0, 7}` gives empty groups → `inv_group_sizes = 1/0 = inf`.
+* `n_groups >= 2`, else `1/(n_groups-1)` divides by zero.
+* `n_groups < n`, else `1/(n-n_groups)` divides by zero.
+* `mat` must be symmetric with a zero diagonal; only the strict upper triangle
+  is read.
+* `mat` is `n*n` contiguous row-major; there is no stride parameter.

--- a/docs/public-c-api.md
+++ b/docs/public-c-api.md
@@ -1,0 +1,132 @@
+# Public C API
+
+The entire shipped surface is three headers, installed to
+`$PREFIX/include/scikit-bio-binaries/`, backed by `$PREFIX/lib/libskbb.so`.
+Implementations are one-line forwarders in `src/extern/skbb_*.cpp` — never put
+logic there.
+
+All matrices are **contiguous row-major `n_dims × n_dims`**, no strides. All
+output buffers are **caller-allocated**. Nothing returns an error code; invalid
+input is undefined behaviour (see the contracts in
+[`permanova.md`](permanova.md#caller-contract-enforced-nowhere--validate-upstream)
+and [`pcoa-fsvd.md`](pcoa-fsvd.md#constraints-and-gotchas)).
+
+## Versioning
+
+```c
+#define SKBB_API_CURRENT_VERSION 1        /* in util.h — bump on ANY API change */
+unsigned int skbb_get_api_version(void);  /* what the loaded .so provides */
+```
+
+Each feature group also declares a floor, so a `ctypes`-style consumer can
+feature-detect:
+
+| Constant | Covers |
+|---|---|
+| `SKBB_RANDOM_API_MIN_VERSION` | `skbb_set_random_seed` |
+| `SKBB_ACC_API_MIN_VERSION` | the `skbb_*_acc_*` group |
+| `SKBB_PERMANOVA_API_MIN_VERSION` | `skbb_permanova_*` |
+| `SKBB_CDM_API_MIN_VERSION` | `skbb_center_distance_matrix_*` |
+| `SKBB_FSVD_API_MIN_VERSION` | `skbb_fsvd_inplace_*` |
+| `SKBB_PCOA_FSVD_API_MIN_VERSION` | `skbb_pcoa_fsvd_*` |
+
+When adding a function: add its `*_MIN_VERSION` constant, bump
+`SKBB_API_CURRENT_VERSION`, and add the header to `SHBB_EXTERN_HS` in
+`src/Makefile` if the header itself is new. The version check does **not** cover
+the dlopen'd GPU plugins.
+
+## `util.h`
+
+```c
+unsigned int skbb_get_api_version();
+void         skbb_set_random_seed(unsigned int new_seed);   /* global generator */
+
+#define SKBB_ACC_CPU 0
+#define SKBB_ACC_NV  1
+#define SKBB_ACC_AMD 2
+unsigned int skbb_get_acc_mode();                  /* forces detection */
+bool         skbb_set_acc_mode(unsigned int t);    /* false if t not compiled in */
+bool         skbb_is_acc_reporting();
+void         skbb_set_acc_reporting_flag(bool);
+```
+
+Under C, `util.h` pulls in `<stdbool.h>`; under C++ it defines `EXTERN extern "C"`.
+The x86-level equivalents (`check_use_cpu_x86` etc.) are **internal only** —
+`src/util/skbb_detect_acc.hpp`, not exported.
+
+## `distance.h`
+
+```c
+void skbb_permanova_fp64(unsigned int n_dims, const double mat[],
+                         const unsigned int grouping[], unsigned int n_perm,
+                         int seed, double *fstat_ptr, double *pvalue_ptr);
+void skbb_permanova_fp32(…float…);
+```
+
+* `grouping`: dense 0-based labels, length `n_dims`, `2 <= n_groups < n_dims`.
+* `n_perm == 0` → `pvalue = 0.0`.
+* `seed < 0` → use the global generator.
+
+## `ordination.h`
+
+```c
+/* centering; mat and centered MAY alias */
+void skbb_center_distance_matrix_fp64(unsigned int n, const double mat[], double centered[]);
+void skbb_center_distance_matrix_fp32(unsigned int n, const float  mat[], float  centered[]);
+void skbb_center_distance_matrix_fp64_to_fp32(unsigned int n, const double mat[], float centered[]);
+
+/* eigendecomposition of an ALREADY centered matrix; `centered` is destroyed */
+void skbb_fsvd_inplace_fp64(unsigned int n, double centered[], unsigned int n_eighs,
+                            int seed, double eigenvalues[], double eigenvectors[]);
+void skbb_fsvd_inplace_fp32(…float…);
+
+/* full PCoA */
+void skbb_pcoa_fsvd_fp64(unsigned int n, const double mat[], unsigned int n_eighs,
+                         int seed, double eigenvalues[], double samples[],
+                         double proportion_explained[]);
+void skbb_pcoa_fsvd_fp32(…float…);
+void skbb_pcoa_fsvd_fp64_to_fp32(unsigned int n, const double mat[], …float outputs…);
+
+/* same, but uses `mat` as the scratch buffer — DESTROYS the input */
+void skbb_pcoa_fsvd_inplace_fp64(unsigned int n, double mat[], …);
+void skbb_pcoa_fsvd_inplace_fp32(unsigned int n, float  mat[], …);
+```
+
+Buffer sizes: `eigenvalues` and `proportion_explained` are `n_eighs`;
+`eigenvectors` and `samples` are `n_dims * n_eighs`, **row-major with one row per
+sample** (the header's "(n_eighs x n_dims)" wording is misleading; the element
+count is the same). `n_eighs <= n_dims`. The three output buffers must not alias
+each other — `proportion_explained` is used as scratch during compute.
+
+Eigenvectors are not unit-normalized and their sign is arbitrary.
+
+## Consuming the library
+
+Compiled languages:
+
+```sh
+$(CC) $(CFLAGS) my_code.c $(LDFLAGS) -lskbb -o my_exe    # see api_tests/Makefile
+```
+
+Python, without any header:
+
+```python
+import ctypes
+dll = ctypes.CDLL("libskbb.so")
+dll.skbb_get_api_version()
+```
+
+Static/embedded consumers: `libskbb_inmem.a` (native) or `libskbb_wasm.a`
+(emscripten) expose the identical symbol set with no BLAS/LAPACK dependency —
+see [`build-system.md`](build-system.md). Downstream emscripten link:
+
+```sh
+emcc my_code.c src/libskbb_wasm.a -sEXIT_RUNTIME=1 -I src/extern -o my_code.js
+```
+
+## Runtime knobs a caller may care about
+
+`SKBB_USE_GPU`, `SKBB_USE_NVIDIA_GPU`, `SKBB_USE_AMD_GPU`, `SKBB_MAX_CPU`,
+`SKBB_GPU_INFO`, `SKBB_CPU_INFO`, `SKBB_TIMING_INFO`, `OMP_NUM_THREADS` —
+documented in [`acceleration-dispatch.md`](acceleration-dispatch.md#environment-variables).
+`OMP_NUM_THREADS` changes seeded PERMANOVA p-values.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,111 @@
+# Testing
+
+Four suites, three harnesses, no framework.
+
+| Suite | Location | Links against | Run with |
+|---|---|---|---|
+| Native unit | `src/tests/test_{pcoa,permanova}.cpp` | `libskbb_cpu.a` (internal C++ API, `skbb::`) | `make -C src test` |
+| Public C API | `api_tests/test_{distance,ordination}.c` | installed `-lskbb`, **C99** | `make -C api_tests test` |
+| WASM unit | `src/tests/wasm/test_*_wasm.cpp` | `libskbb_wasm.a` | `make wasm_test` (node) |
+| WASM public API | the same `api_tests/*.c` under `emcc` | `libskbb_wasm.a` | `make wasm_api_test` |
+
+`make test` at the top level runs the first two. There is no `ctest`, no Catch2;
+the harness is a set of macros in `src/tests/test_helper.hpp` (`SUITE_START`,
+`ASSERT`, `SUITE_END`) adapted from BitArray's test harness.
+
+## Native unit tests
+
+`src/tests/test_permanova.cpp` runs each suite **twice** — once before and once
+after forcing `skbb::set_use_acc(ACC_CPU)` and (where compiled in)
+`set_use_cpu_x86(CPU_X86_BASE)`. That is how the dispatch paths get exercised on
+a machine that has AVX512 or a GPU: first pass uses whatever was detected,
+second pass uses the baseline. Keep that structure when adding cases.
+
+Expected values come from **scikit-bio** for the statistic (`exp_stat`) and are
+loose for the p-value (`|Δ| < 0.05`) because the RNG differs from scikit-bio's.
+Tolerance on `fstat` is `1e-5`.
+
+`src/tests/test_pcoa.cpp` compares against hard-coded expected matrices from
+scikit-bio (unweighted UniFrac of `test.biom` and `crawford.biom`). Eigenvector
+comparisons use `fabs(fabs(got) - fabs(want))` because sign is arbitrary.
+
+Both `main()`s return `tests_failed ? EXIT_FAILURE : EXIT_SUCCESS`.
+
+## Public C API tests
+
+These are the ABI contract tests: compiled as **C99**, including only the
+installed public headers, linking `-lskbb`. They require `make install` first
+and `$PREFIX/lib` on the loader path. They also assert
+`skbb_get_api_version() == SKBB_API_CURRENT_VERSION`, i.e. that the built header
+and the built library agree.
+
+> Their `main()` returns `failed ? 1 : 0` where `failed` is reset to `0` at the
+> start of every test function — so a failure in an earlier function is masked by
+> a later one that passes. `global_failed` is tracked but never used for the
+> exit code. See [`known-issues.md`](known-issues.md#api_tests-exit-code-masks-earlier-failures).
+
+## WASM parity suite
+
+The interesting one. It proves the emscripten build behaves like the native
+build, and it is the reason several design choices exist (portable shuffle, the
+WASM `pmn_get_max_parallelism` value).
+
+```
+src/tests/wasm/
+  permanova_inputs.hpp   pcoa_inputs.hpp        # fixed inputs, SHARED by generator + test
+  generate_permanova_expected.cpp               # NATIVE binary -> prints a C header
+  generate_pcoa_expected.cpp
+  expected/*.h                                  # GENERATED, .gitignore'd
+  test_smoke.cpp  test_permanova_wasm.cpp  test_center_wasm.cpp  test_pcoa_wasm.cpp
+```
+
+Flow: `make wasm_test` builds the native `libskbb_cpu.a`, builds and runs the
+generators **with `OMP_NUM_THREADS=1`** (enforced twice — by the Makefile rule
+and by an explicit check inside the generator, which exits 2 otherwise), writes
+`expected/*.h`, then compiles the WASM tests against those headers and runs them
+under node.
+
+Expected values are emitted with `%a` (exact hex float) so the round-trip through
+the header is lossless, with a `%.17g` decimal in a comment for readability.
+
+**The expected headers are not committed.** That was explicit maintainer
+feedback on PR #12 ("Why do we check in the expected files, if they have been
+dynamically generated?"). They are in `.gitignore`; regenerate by deleting
+`src/tests/wasm/expected/` and re-running `make wasm_test`.
+
+Tolerances (also documented in `README.rst`):
+
+| Check | Tolerance |
+|---|---|
+| PERMANOVA `fstat`, `pvalue` | **bit-identical** (`==`) |
+| `mat_to_centered` | 1e-6 absolute |
+| PCoA eigenvalues, proportion_explained | 1e-6 absolute |
+| PCoA sample coordinates | 1e-3 absolute, sign-adjusted per axis |
+
+Every WASM test also runs its call **twice with identical inputs** and asserts
+bit-equality, catching RNG state leaking between calls.
+
+The sign-adjustment helper in `test_pcoa_wasm.cpp` handles sign flips only. If a
+future case has near-degenerate eigenvalues the whole eigenspace can rotate and
+a subspace-distance check would be needed instead — the file says so, and the
+current 6×6 cases have a well-separated spectrum.
+
+## Adding tests
+
+* New algorithm → add to all four suites. The WASM inputs header must be shared
+  by the generator and the test so they cannot drift; both use the
+  `static_assert(sizeof(expected)/sizeof(expected[0]) == kCaseCount)` guard.
+* Prefer expected values from scikit-bio where a reference exists; state in a
+  comment where the number came from.
+* If a test produces an incorrect expected value, **do not change the expected
+  value** — find out why.
+* Run `make test` with a non-power-of-two `OMP_NUM_THREADS` (CI uses 3) — chunk
+  arithmetic bugs hide at thread counts of 1.
+
+## Local reproduction of CI
+
+CI's WASM job runs on bare Ubuntu with apt-provided BLAS, not conda, and needs
+`BLASLIB="-llapacke -lopenblas"` plus `libblas-dev` for `cblas.h`. A conda env on
+the developer machine silently supplies headers the runner lacks — the class of
+failure that produced two consecutive CI-fix commits. When touching the link
+line, reproduce in a clean container rather than trusting a local conda build.


### PR DESCRIPTION
## Summary

Documentation only. No build, source, or test changes — the diff is 12 new
Markdown files.

Coding assistants (Claude Code and similar) re-derive the same facts about this
repository at the start of every session. That is slow, and it produces changes
that do not match the conventions here. This adds a `CLAUDE.md` entry point plus
eleven topic documents under `docs/`, so that context can be loaded selectively
instead of by re-reading the tree.

The documents were written from a full read of the sources, not from the README,
and they concentrate on the things that are non-obvious from any single file.

## What is in it

`CLAUDE.md` — project overview, priorities, build/test commands, and a link to
each topic document with a note on when it is relevant. It also states the
expectations that are easiest for an assistant to get wrong here:

- **Match the file being edited.** Indentation genuinely varies across the tree
  (1-space, 2-space, 4-space, tabs) and there is no formatter or format check to
  normalize it, so a reformat is never free — it is reviewer cost with no
  offsetting benefit.
- **No churn outside the task.** No reformatting, re-wrapping, typo-fixing, or
  modernizing of code that is not part of the change.
- **Comments must be succinct and durable** — explain *why*, written for someone
  reading the file in two years. Do not narrate the change that introduced them.

That last point is drawn from this repo's own history: the comment block at
`src/tests/wasm/generate_permanova_expected.cpp:15-25` still states that the
expected-value headers are checked into the repo and names a
`wasm_regen_permanova_expected` make target. Both were reversed during the
review of #12, so the comment now actively misleads. It described a pull request
rather than the code.

`docs/` — one document per topic:

| Document | Covers |
| --- | --- |
| `architecture.md` | layering, directory map, the `SKBB_ACC_NM` multi-namespace include idiom |
| `code-style.md` | per-file conventions, comment policy, prior review feedback |
| `build-system.md` | targets and variables, `skbb_cpu_tu`, generated sources, CI |
| `codegen.md` | the `_T` → wrapper generators and the parser's constraints |
| `acceleration-dispatch.md` | runtime CPU/GPU selection, env vars, the dlopen plugins |
| `permanova.md` | the statistic, chunking, `NBLOCK`/`TILE` blocking, the kernels |
| `pcoa-fsvd.md` | centering, the six FSVD steps, the linalg backend contracts |
| `determinism-and-numerics.md` | what is bit-reproducible and what is not |
| `testing.md` | the four suites and the native → WASM expected-value flow |
| `public-c-api.md` | exported symbols, buffer contracts, API versioning |
| `known-issues.md` | defects and latent fragilities found while writing the above |

## Notes for review

- The guidance encodes the review feedback from #12 as standing requirements:
  do not duplicate build infrastructure (add a translation unit once, via
  `skbb_cpu_tu`), and do not commit generated artifacts.
- `docs/known-issues.md` records findings, not fixes. Nothing in it is changed
  by this PR, and it explicitly says such items get their own commit and test
  rather than being folded into unrelated work. The PERMANOVA correctness item
  is filed separately with a reproducer.
- Happy to drop or reshape any document that reads as noise — the intent is that
  each one earns its place by answering a question that currently requires
  reading several files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
